### PR TITLE
Add fixed effects support with pyfixest integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,62 @@ print(analyzer.results[["outcome", "absolute_effect", "trimmed_units"]])
 | When overlap is poor | Handles gracefully | May drop many units |
 | Use as robustness check | Yes | Yes |
 
+### Fixed Effects (Panel / Within-Unit Estimation)
+
+Use `fixed_effects` to absorb unit-level (or strata-level) variation in panel and switchback designs, where the same unit appears in both treatment and control conditions across time.
+
+**When to use:**
+- Repeated-measures / panel experiments where units switch between treatment and control (e.g. switchback A/B tests on tutors, drivers, or listings).
+- Designs with strong unit-level heterogeneity you want to partial out (e.g. within-tutor or within-store effects).
+- Strata fixed effects to control for known grouping structure.
+
+**New constructor parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `fixed_effects` | `list[str] \| str \| None` | `None` | Column(s) whose levels are absorbed as fixed effects |
+| `fixed_effects_min_switcher_pct` | `float` | `10.0` | Warn when the share of switcher units drops below this threshold (%) |
+
+**Switcher identification:** with unit fixed effects, only units observed in **both** treatment and control conditions ("switchers") identify the treatment effect. The results DataFrame includes three diagnostic columns:
+
+| Column | Description |
+|---|---|
+| `n_units` | Total unique units in the estimation sample |
+| `n_switchers` | Units observed in both treatment and control |
+| `pct_switchers` | `n_switchers / n_units × 100` |
+| `fe_absorbed` | Name(s) of the absorbed fixed-effect column(s) |
+
+A warning is emitted when `pct_switchers` falls below `fixed_effects_min_switcher_pct`.
+
+**Backend and supported models:**
+
+Fixed effects estimation uses [pyfixest](https://github.com/py-econometrics/pyfixest) (`feols` for OLS, `fepois` for Poisson). Fixed effects are supported for `ols` and `poisson` model types combined with `adjustment=None` or `adjustment="balance"`. For `logistic`, `negative_binomial`, `cox`, or IV/AIPW estimators, a warning is issued and the analysis runs **without** fixed effects.
+
+Variance estimation: clustered (`CRV1`) when `cluster_col` is provided; heteroskedasticity-robust (`"hetero"`) otherwise.
+
+> **Note on relative effects under OLS fixed effects:** the intercept is absorbed, so relative effects are computed against the control-group mean of the estimation sample (a delta approximation). The Fieller-based exact relative CI does not apply in this case.
+
+**Example:**
+
+```python
+analyzer = ExperimentAnalyzer(
+    data=df,
+    outcomes=["revenue"],
+    treatment_col="treatment",
+    regression_covariates=["tenure_days"],  # time-varying control
+    fixed_effects=["tutor_id"],             # within-tutor identification
+    cluster_col="tutor_id",                 # optional clustered SEs
+)
+
+analyzer.get_effects()
+res = analyzer.results
+
+# res includes n_units, n_switchers, pct_switchers, fe_absorbed
+print(res[["outcome", "absolute_effect", "pvalue", "n_units", "n_switchers", "pct_switchers", "fe_absorbed"]])
+```
+
+See [`examples/fixed_effects_example.py`](examples/fixed_effects_example.py) for a full runnable demonstration with synthetic panel data.
+
 ### Outcome Models
 
 By default, all outcomes are analyzed with OLS. Use `outcome_models` to specify different model types:

--- a/examples/fixed_effects_example.py
+++ b/examples/fixed_effects_example.py
@@ -1,0 +1,64 @@
+# %% Imports
+import numpy as np
+import pandas as pd
+from numpy.random import default_rng
+
+from experiment_utils.experiment_analyzer import ExperimentAnalyzer
+
+# %% Simulate a within-unit panel dataset
+# 80 units x 6 periods; treatment switches within unit so units are "switchers"
+rng = default_rng(42)
+
+n_units = 80
+n_periods = 6
+true_effect = 2.5
+
+unit_ids = np.repeat(np.arange(n_units), n_periods)
+period_ids = np.tile(np.arange(n_periods), n_units)
+
+# Unit-level heterogeneity (fixed effect)
+unit_fe = rng.normal(0, 5, n_units)
+unit_fe_expanded = np.repeat(unit_fe, n_periods)
+
+# Time-varying covariate
+cov = rng.normal(0, 1, n_units * n_periods)
+
+# Treatment varies within unit: each unit is treated in some periods
+treatment = rng.binomial(1, 0.5, n_units * n_periods)
+
+# Outcome: unit FE + treatment effect + covariate effect + noise
+outcome = unit_fe_expanded + true_effect * treatment + 0.8 * cov + rng.normal(0, 1, n_units * n_periods)
+
+df = pd.DataFrame(
+    {
+        "unit": unit_ids,
+        "period": period_ids,
+        "treatment": treatment,
+        "cov": cov,
+        "revenue": outcome,
+    }
+)
+
+print(f"Dataset: {df.shape[0]} rows, {n_units} units, {n_periods} periods")
+print(f"True treatment effect: {true_effect}")
+
+# %% Run ExperimentAnalyzer with unit fixed effects
+analyzer = ExperimentAnalyzer(
+    data=df,
+    outcomes=["revenue"],
+    treatment_col="treatment",
+    regression_covariates=["cov"],  # time-varying control
+    fixed_effects=["unit"],  # within-unit identification
+    cluster_col="unit",  # clustered standard errors
+    fixed_effects_min_switcher_pct=10.0,
+)
+
+analyzer.get_effects()
+res = analyzer.results
+
+# %% Print key diagnostics
+diag_cols = [c for c in ["fe_absorbed", "n_units", "n_switchers", "pct_switchers"] if c in res.columns]
+effect_cols = ["outcome", "model_type", "absolute_effect", "pvalue", "stat_significance"] + diag_cols
+
+print("\n--- Fixed Effects Results ---")
+print(res[effect_cols].to_string(index=False))

--- a/experiment_utils/estimators.py
+++ b/experiment_utils/estimators.py
@@ -341,6 +341,213 @@ class Estimators:
 
         return output
 
+    def fixed_effects_regression(
+        self,
+        data: pd.DataFrame,
+        outcome_variable: str,
+        fixed_effects: list[str],
+        covariates: list[str] | None = None,
+        cluster_col: str | None = None,
+        model_type: str = "ols",
+        interaction_covariates: list[str] | None = None,
+        weight_column: str | None = None,
+        store_model: bool = False,
+        min_switcher_pct: float = 10.0,
+        compute_relative_ci: bool = True,
+        **kwargs,
+    ) -> dict[str, str | int | float]:
+        """
+        Fixed-effects regression via pyfixest (OLS=feols, Poisson=fepois).
+
+        Absorbs ``fixed_effects`` (e.g. ["tutor_id", "week"]); the treatment effect is
+        identified from within-fixed-effect variation. Returns the same result dict as
+        ``linear_regression``/``poisson_regression`` plus switcher diagnostics
+        (``n_units``, ``n_switchers``, ``pct_switchers``, ``fe_absorbed``).
+
+        Notes
+        -----
+        - ``cluster_col`` -> ``vcov={"CRV1": cluster_col}``; otherwise ``"hetero"``.
+        - ``df_resid`` is set to ``float(fit._df_t)`` so the analyzer's downstream
+          Wald CI reconstruction reproduces pyfixest's CI exactly.
+        - Under FE the intercept is absorbed, so relative effects are taken against the
+          control-group mean of the estimation sample (delta approximation); Fieller
+          fields are NaN.
+        """
+        try:
+            import pyfixest as pf
+        except ImportError:
+            log_and_raise_error(
+                self._logger,
+                "fixed_effects requires pyfixest. Install with `uv add pyfixest`.",
+            )
+
+        covariates = covariates or []
+        interaction_covariates = interaction_covariates or []
+        z_covs = [f"z_{c}" for c in covariates]
+        z_ints = [f"z_{c}" for c in interaction_covariates]
+
+        # Drop NA on model columns FIRST so switcher counts match the fitted rows.
+        model_cols = list(dict.fromkeys([outcome_variable, self._treatment_col, *z_covs, *z_ints, *fixed_effects]))
+        if cluster_col:
+            model_cols.append(cluster_col)
+        if weight_column:
+            model_cols.append(weight_column)
+        data = data.dropna(subset=model_cols).copy()
+
+        # Switcher diagnostics on the first FE column (the documented "unit" dimension).
+        unit_fe = fixed_effects[0]
+        states = data.groupby(unit_fe)[self._treatment_col].nunique()
+        n_units = int(states.size)
+        n_switchers = int((states > 1).sum())
+        pct_switchers = round(100.0 * n_switchers / n_units, 1) if n_units else float("nan")
+        fe_absorbed = "+".join(fixed_effects)
+        if n_units and pct_switchers < min_switcher_pct:
+            self._logger.warning(
+                f"Only {pct_switchers}% of '{unit_fe}' are switchers (observed in both arms); "
+                f"the fixed-effects estimate for '{outcome_variable}' is identified off a thin sample."
+            )
+
+        # Build the pyfixest formula from already-standardized z_ columns.
+        rhs = " + ".join(z_covs + [self._treatment_col]) if z_covs else self._treatment_col
+        for c in interaction_covariates:
+            rhs += f" + z_{c} + {self._treatment_col}:z_{c}"
+        formula = f"{outcome_variable} ~ {rhs} | {' + '.join(fixed_effects)}"
+
+        vcov = {"CRV1": cluster_col} if cluster_col else "hetero"
+        treatment_units = int((data[self._treatment_col] == 1).sum())
+        control_units = int((data[self._treatment_col] == 0).sum())
+        control_mean = data.loc[data[self._treatment_col] == 0, outcome_variable].mean()
+
+        if model_type == "poisson":
+            fit = pf.fepois(formula, data=data, vcov=vcov)
+        else:
+            fit_kwargs = {"fml": formula, "data": data, "vcov": vcov}
+            if weight_column:
+                fit_kwargs["weights"] = weight_column
+            fit = pf.feols(**fit_kwargs)
+
+        tidy = fit.tidy()
+        if self._treatment_col not in tidy.index:
+            # Treatment was dropped (collinear with FE: no within-FE variation).
+            self._logger.error(
+                f"Treatment '{self._treatment_col}' is collinear with fixed effects for "
+                f"'{outcome_variable}' (n_switchers={n_switchers}); no effect is identified."
+            )
+            return self.__fixed_effects_nan_output(
+                outcome_variable,
+                model_type,
+                treatment_units,
+                control_units,
+                control_mean,
+                n_units,
+                n_switchers,
+                pct_switchers,
+                fe_absorbed,
+            )
+
+        row = tidy.loc[self._treatment_col]
+        coefficient = float(row["Estimate"])
+        standard_error = float(row["Std. Error"])
+        pvalue = float(row["Pr(>|t|)"])
+        df_resid = float(fit._df_t)
+        ci = fit.confint(alpha=self._alpha).loc[self._treatment_col]
+        ci_lower, ci_upper = float(ci.iloc[0]), float(ci.iloc[1])
+
+        if model_type == "poisson":
+            irr = float(np.exp(coefficient))
+            output = {
+                "outcome": outcome_variable,
+                "treatment_units": treatment_units,
+                "control_units": control_units,
+                "control_value": control_mean,
+                "treatment_value": control_mean * irr,
+                "absolute_effect": coefficient,
+                "relative_effect": irr - 1,
+                "standard_error": standard_error,
+                "pvalue": pvalue,
+                "stat_significance": 1 if pvalue < self._alpha else 0,
+                "incidence_rate_ratio": irr,
+                "log_irr": coefficient,
+                "marginal_effect": None,
+                "model_type": "poisson",
+                "effect_type": "log_rate_ratio",
+                "rel_effect_lower": float(np.exp(ci_lower) - 1),
+                "rel_effect_upper": float(np.exp(ci_upper) - 1),
+                "se_intercept": np.nan,
+                "cov_coef_intercept": np.nan,
+                "df_resid": df_resid,
+            }
+        else:
+            rel = coefficient / control_mean if control_mean else np.nan
+            output = {
+                "outcome": outcome_variable,
+                "treatment_units": treatment_units,
+                "control_units": control_units,
+                "control_value": control_mean,
+                "treatment_value": control_mean + coefficient,
+                "absolute_effect": coefficient,
+                "standard_error": standard_error,
+                "pvalue": pvalue,
+                "stat_significance": 1 if pvalue < self._alpha else 0,
+                "relative_effect": rel,
+                "rel_effect_lower": (ci_lower / control_mean) if control_mean else np.nan,
+                "rel_effect_upper": (ci_upper / control_mean) if control_mean else np.nan,
+                "se_intercept": np.nan,
+                "cov_coef_intercept": np.nan,
+                "df_resid": df_resid,
+                "model_type": "ols",
+                "effect_type": "mean_difference",
+            }
+
+        output.update(
+            {
+                "n_units": n_units,
+                "n_switchers": n_switchers,
+                "pct_switchers": pct_switchers,
+                "fe_absorbed": fe_absorbed,
+            }
+        )
+        if store_model:
+            output["fitted_model"] = fit
+        return output
+
+    def __fixed_effects_nan_output(
+        self,
+        outcome_variable,
+        model_type,
+        treatment_units,
+        control_units,
+        control_mean,
+        n_units,
+        n_switchers,
+        pct_switchers,
+        fe_absorbed,
+    ) -> dict:
+        """NaN-effect result (treatment collinear with FE) carrying diagnostics."""
+        return {
+            "outcome": outcome_variable,
+            "treatment_units": treatment_units,
+            "control_units": control_units,
+            "control_value": control_mean,
+            "treatment_value": np.nan,
+            "absolute_effect": np.nan,
+            "relative_effect": np.nan,
+            "standard_error": np.nan,
+            "pvalue": np.nan,
+            "stat_significance": 0,
+            "rel_effect_lower": np.nan,
+            "rel_effect_upper": np.nan,
+            "se_intercept": np.nan,
+            "cov_coef_intercept": np.nan,
+            "df_resid": np.nan,
+            "model_type": model_type,
+            "effect_type": "mean_difference" if model_type == "ols" else "log_rate_ratio",
+            "n_units": n_units,
+            "n_switchers": n_switchers,
+            "pct_switchers": pct_switchers,
+            "fe_absorbed": fe_absorbed,
+        }
+
     def weighted_least_squares(
         self,
         data: pd.DataFrame,

--- a/experiment_utils/estimators.py
+++ b/experiment_utils/estimators.py
@@ -419,7 +419,10 @@ class Estimators:
         control_mean = data.loc[data[self._treatment_col] == 0, outcome_variable].mean()
 
         if model_type == "poisson":
-            fit = pf.fepois(formula, data=data, vcov=vcov)
+            pois_kwargs = {"fml": formula, "data": data, "vcov": vcov}
+            if weight_column:
+                pois_kwargs["weights"] = weight_column
+            fit = pf.fepois(**pois_kwargs)
         else:
             fit_kwargs = {"fml": formula, "data": data, "vcov": vcov}
             if weight_column:

--- a/experiment_utils/estimators.py
+++ b/experiment_utils/estimators.py
@@ -450,8 +450,13 @@ class Estimators:
         standard_error = float(row["Std. Error"])
         pvalue = float(row["Pr(>|t|)"])
         df_resid = float(fit._df_t)
-        ci = fit.confint(alpha=self._alpha).loc[self._treatment_col]
-        ci_lower, ci_upper = float(ci.iloc[0]), float(ci.iloc[1])
+
+        # Relative-effect CI bounds (skip during bootstrap: percentiles fill them later).
+        if compute_relative_ci:
+            ci = fit.confint(alpha=self._alpha).loc[self._treatment_col]
+            ci_lower, ci_upper = float(ci.iloc[0]), float(ci.iloc[1])
+        else:
+            ci_lower, ci_upper = np.nan, np.nan
 
         if model_type == "poisson":
             irr = float(np.exp(coefficient))
@@ -471,14 +476,19 @@ class Estimators:
                 "marginal_effect": None,
                 "model_type": "poisson",
                 "effect_type": "log_rate_ratio",
-                "rel_effect_lower": float(np.exp(ci_lower) - 1),
-                "rel_effect_upper": float(np.exp(ci_upper) - 1),
+                "rel_effect_lower": float(np.exp(ci_lower) - 1) if compute_relative_ci else np.nan,
+                "rel_effect_upper": float(np.exp(ci_upper) - 1) if compute_relative_ci else np.nan,
                 "se_intercept": np.nan,
                 "cov_coef_intercept": np.nan,
                 "df_resid": df_resid,
             }
         else:
             rel = coefficient / control_mean if control_mean else np.nan
+            if compute_relative_ci and control_mean:
+                rel_effect_lower = ci_lower / control_mean
+                rel_effect_upper = ci_upper / control_mean
+            else:
+                rel_effect_lower, rel_effect_upper = np.nan, np.nan
             output = {
                 "outcome": outcome_variable,
                 "treatment_units": treatment_units,
@@ -490,8 +500,8 @@ class Estimators:
                 "pvalue": pvalue,
                 "stat_significance": 1 if pvalue < self._alpha else 0,
                 "relative_effect": rel,
-                "rel_effect_lower": (ci_lower / control_mean) if control_mean else np.nan,
-                "rel_effect_upper": (ci_upper / control_mean) if control_mean else np.nan,
+                "rel_effect_lower": rel_effect_lower,
+                "rel_effect_upper": rel_effect_upper,
                 "se_intercept": np.nan,
                 "cov_coef_intercept": np.nan,
                 "df_resid": df_resid,

--- a/experiment_utils/experiment_analyzer.py
+++ b/experiment_utils/experiment_analyzer.py
@@ -306,6 +306,8 @@ class ExperimentAnalyzer(BootstrapMixin, RetrodesignMixin, MetaAnalysisMixin):
         store_fitted_models: bool = True,
         event_col: str | None = None,
         interaction_covariates: list[str] | None = None,
+        fixed_effects: list[str] | str | None = None,
+        fixed_effects_min_switcher_pct: float = 10.0,
         ratio_outcomes: dict[str, tuple[str, str]] | None = None,
     ) -> None:
         self._logger = get_logger("Experiment Analyzer")
@@ -374,6 +376,8 @@ class ExperimentAnalyzer(BootstrapMixin, RetrodesignMixin, MetaAnalysisMixin):
         self._store_fitted_models = store_fitted_models
         self._event_col = event_col
         self._interaction_covariates = self.__ensure_list(interaction_covariates)
+        self._fixed_effects = self.__ensure_list(fixed_effects)
+        self._fixed_effects_min_switcher_pct = fixed_effects_min_switcher_pct
         self._all_covariates = list(dict.fromkeys(self._balance_covariates + self._regression_covariates))
 
         # Validate and store ratio outcomes: {name: (numerator_col, denominator_col)}
@@ -447,6 +451,17 @@ class ExperimentAnalyzer(BootstrapMixin, RetrodesignMixin, MetaAnalysisMixin):
         # Collect numerator and denominator columns for ratio outcomes
         ratio_raw_cols = [col for pair in self._ratio_outcomes.values() for col in pair]
 
+        # Validate fixed_effects before building required_columns so missing FE
+        # columns are dropped from self._fixed_effects (warn+drop) and surviving
+        # FE columns are retained in self._data by the subset below.
+        if self._fixed_effects:
+            missing_fe = [c for c in self._fixed_effects if c not in self._data.columns]
+            if missing_fe:
+                self._logger.warning(f"fixed_effects columns not found in data and will be skipped: {missing_fe}")
+                self._fixed_effects = [c for c in self._fixed_effects if c in self._data.columns]
+            if self._treatment_col in self._fixed_effects:
+                log_and_raise_error(self._logger, "treatment_col cannot be listed in fixed_effects.")
+
         required_columns = (
             self._experiment_identifier
             + [self._treatment_col]
@@ -459,6 +474,7 @@ class ExperimentAnalyzer(BootstrapMixin, RetrodesignMixin, MetaAnalysisMixin):
             + ([self._cluster_col] if self._cluster_col is not None else [])
             + ([self._event_col] if self._event_col is not None else [])
             + (self._interaction_covariates if self._interaction_covariates else [])
+            + (self._fixed_effects if self._fixed_effects else [])
             + ratio_raw_cols
         )
 

--- a/experiment_utils/experiment_analyzer.py
+++ b/experiment_utils/experiment_analyzer.py
@@ -1493,6 +1493,12 @@ class ExperimentAnalyzer(BootstrapMixin, RetrodesignMixin, MetaAnalysisMixin):
         else:
             original_bootstrap = None
 
+        if self._bootstrap and self._fixed_effects:
+            self._logger.warning(
+                "bootstrap=True is ignored for fixed-effects outcomes; analytic pyfixest "
+                "standard errors are used for fixed-effects estimates."
+            )
+
         self._balance = []
         self._adjusted_balance = []
         self._precision_summary = pd.DataFrame()
@@ -2112,7 +2118,7 @@ class ExperimentAnalyzer(BootstrapMixin, RetrodesignMixin, MetaAnalysisMixin):
                                 else:
                                     self._fitted_models[experiment_tuple][comp_key][outcome] = fitted
 
-                            if self._bootstrap:
+                            if self._bootstrap and not use_fe:
                                 skip_bootstrap = False
                                 if model_type == "cox" and self._skip_bootstrap_for_survival:
                                     self._logger.info(
@@ -2235,7 +2241,9 @@ class ExperimentAnalyzer(BootstrapMixin, RetrodesignMixin, MetaAnalysisMixin):
                                 output["rel_effect_lower"] = output.get("rel_effect_lower", np.nan)
                                 output["rel_effect_upper"] = output.get("rel_effect_upper", np.nan)
 
-                            output["inference_method"] = "bootstrap" if self._bootstrap else "asymptotic"
+                            output["inference_method"] = (
+                                "bootstrap" if (self._bootstrap and not use_fe) else "asymptotic"
+                            )
                             output["adjustment"] = adjustment_label
                             if adjustment in ("balance", "aipw"):
                                 output["method"] = self._balance_method

--- a/experiment_utils/experiment_analyzer.py
+++ b/experiment_utils/experiment_analyzer.py
@@ -2018,6 +2018,25 @@ class ExperimentAnalyzer(BootstrapMixin, RetrodesignMixin, MetaAnalysisMixin):
                                     f"with model_type='{model_type}' — only supported for OLS."
                                 )
 
+                            use_fe = (
+                                bool(self._fixed_effects)
+                                and model_type in {"ols", "poisson"}
+                                and adjustment in {None, "balance"}
+                            )
+                            if self._fixed_effects and not use_fe:
+                                self._logger.warning(
+                                    f"fixed_effects ignored for outcome '{outcome}' "
+                                    f"(model_type='{model_type}', adjustment={adjustment}): "
+                                    "FE is supported only for ols/poisson without IV/AIPW."
+                                )
+                            if use_fe:
+                                estimator_func = self._estimator.fixed_effects_regression
+                                estimator_params["fixed_effects"] = self._fixed_effects
+                                estimator_params["model_type"] = model_type
+                                estimator_params["min_switcher_pct"] = self._fixed_effects_min_switcher_pct
+                                # marginal-effects flag is not used by the FE estimator
+                                estimator_params.pop("compute_marginal_effects", None)
+
                             output = estimator_func(**estimator_params)
 
                             # Compute control group SD for retrodesign simulation
@@ -2367,6 +2386,12 @@ class ExperimentAnalyzer(BootstrapMixin, RetrodesignMixin, MetaAnalysisMixin):
             result_columns.append("srm_pvalue")
         if self._trim_ps and "trimmed_units" not in result_columns:
             result_columns.append("trimmed_units")
+
+        # FE diagnostic columns: include when fixed_effects are configured
+        if self._fixed_effects:
+            for _fe_col in ("n_units", "n_switchers", "pct_switchers", "fe_absorbed"):
+                if _fe_col not in result_columns:
+                    result_columns.append(_fe_col)
 
         # Bootstrap-only probability columns: include whenever the bootstrap
         # path populated them (i.e., any row has inference_method="bootstrap").

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "scikit-learn>=1.5.2",
     "xgboost>=2.1.3",
     "lifelines>=0.30.3",
+    "pyfixest>=0.60",
     "tqdm>=4.67.3",
 ]
 

--- a/tests/test_fixed_effects.py
+++ b/tests/test_fixed_effects.py
@@ -248,3 +248,34 @@ def test_fe_diagnostic_columns_present_after_standard_columns():
     cols = list(res.columns)
     assert cols.index("fe_absorbed") > cols.index("absolute_effect")
     assert res.iloc[0]["fe_absorbed"] == "unit"
+
+
+def test_fe_composes_with_interactions_and_clustering():
+    """FE + regression covariates + CUPED interactions + clustered SEs runs end-to-end."""
+    df = analyzer_df(seed=15)
+    a = ExperimentAnalyzer(
+        data=df,
+        outcomes=["y"],
+        treatment_col="treatment",
+        regression_covariates=["cov"],
+        interaction_covariates=["cov"],
+        fixed_effects=["unit"],
+        cluster_col="unit",
+    )
+    a.get_effects()
+    res = a.results
+    assert len(res) >= 1
+    assert res.iloc[0]["fe_absorbed"] == "unit"
+    assert np.isfinite(res.iloc[0]["absolute_effect"])
+    assert res.iloc[0]["n_switchers"] > 0
+
+
+def test_fe_estimator_dropna_alignment():
+    """dropna happens first, so switcher counts match the rows pyfixest fits."""
+    df = make_panel(seed=16)
+    df.loc[df.index[:20], "y"] = np.nan  # introduce missingness in the outcome
+    out = est().fixed_effects_regression(data=df, outcome_variable="y", fixed_effects=["unit"], covariates=["cov"])
+    cleaned = df.dropna(subset=["y", "treatment", "z_cov", "unit"])
+    assert out["n_units"] == cleaned["unit"].nunique()
+    expected_switchers = int((cleaned.groupby("unit")["treatment"].nunique() > 1).sum())
+    assert out["n_switchers"] == expected_switchers

--- a/tests/test_fixed_effects.py
+++ b/tests/test_fixed_effects.py
@@ -180,3 +180,42 @@ def test_fe_column_retained_in_data_after_init():
         fixed_effects=["unit"],
     )
     assert "unit" in a._data.columns
+
+
+def test_get_effects_uses_fe_and_adds_diagnostic_columns():
+    df = analyzer_df(seed=11)
+    a = ExperimentAnalyzer(
+        data=df,
+        outcomes=["y"],
+        treatment_col="treatment",
+        regression_covariates=["cov"],
+        fixed_effects=["unit"],
+        cluster_col="unit",
+    )
+    a.get_effects()
+    res = a._results
+    assert {"n_units", "n_switchers", "pct_switchers", "fe_absorbed"}.issubset(res.columns)
+    row = res.iloc[0]
+    assert row["fe_absorbed"] == "unit"
+    assert row["n_switchers"] > 0
+    assert row["absolute_effect"] == pytest.approx(1.5, abs=0.3)
+
+
+def test_get_effects_fe_warns_and_falls_back_for_logistic(caplog):
+    df = analyzer_df(seed=12)
+    df["bin"] = (df["y"] > df["y"].median()).astype(int)
+    a = ExperimentAnalyzer(
+        data=df,
+        outcomes=["bin"],
+        treatment_col="treatment",
+        outcome_models={"bin": "logistic"},
+        fixed_effects=["unit"],
+    )
+    a.get_effects()
+    res = a._results
+    # logistic ran (no FE), so FE diagnostics are absent or NaN for this row
+    assert res.iloc[0]["model_type"] == "logistic"
+    if "n_switchers" in res.columns:
+        assert pd.isna(res.iloc[0]["n_switchers"])
+    if "fe_absorbed" in res.columns:
+        assert res.iloc[0]["fe_absorbed"] in ("", None) or pd.isna(res.iloc[0]["fe_absorbed"])

--- a/tests/test_fixed_effects.py
+++ b/tests/test_fixed_effects.py
@@ -4,6 +4,7 @@ import pyfixest as pf
 import pytest
 
 from experiment_utils.estimators import Estimators
+from experiment_utils.experiment_analyzer import ExperimentAnalyzer
 
 
 def make_panel(n_units=60, n_periods=6, effect=1.5, seed=0, between_unit=False):
@@ -140,3 +141,42 @@ def test_poisson_fe_recovers_irr():
     assert out["incidence_rate_ratio"] == pytest.approx(np.exp(0.3), abs=0.25)
     assert out["relative_effect"] == pytest.approx(out["incidence_rate_ratio"] - 1)
     assert out["n_switchers"] == 60
+
+
+def analyzer_df(seed=10):
+    df = make_panel(seed=seed)
+    return df
+
+
+def test_init_stores_fixed_effects_as_list():
+    df = analyzer_df()
+    a = ExperimentAnalyzer(
+        data=df,
+        outcomes=["y"],
+        treatment_col="treatment",
+        fixed_effects="unit",  # string normalized to list
+    )
+    assert a._fixed_effects == ["unit"]
+    assert a._fixed_effects_min_switcher_pct == 10.0
+
+
+def test_init_missing_fe_column_warns_and_drops(caplog):
+    df = analyzer_df()
+    a = ExperimentAnalyzer(
+        data=df,
+        outcomes=["y"],
+        treatment_col="treatment",
+        fixed_effects=["unit", "does_not_exist"],
+    )
+    assert a._fixed_effects == ["unit"]
+
+
+def test_fe_column_retained_in_data_after_init():
+    df = analyzer_df()
+    a = ExperimentAnalyzer(
+        data=df,
+        outcomes=["y"],
+        treatment_col="treatment",
+        fixed_effects=["unit"],
+    )
+    assert "unit" in a._data.columns

--- a/tests/test_fixed_effects.py
+++ b/tests/test_fixed_effects.py
@@ -219,3 +219,32 @@ def test_get_effects_fe_warns_and_falls_back_for_logistic(caplog):
         assert pd.isna(res.iloc[0]["n_switchers"])
     if "fe_absorbed" in res.columns:
         assert res.iloc[0]["fe_absorbed"] in ("", None) or pd.isna(res.iloc[0]["fe_absorbed"])
+
+
+def test_non_fe_run_schema_has_no_fe_columns():
+    """Without fixed_effects, FE diagnostic columns are absent (schema unchanged)."""
+    df = analyzer_df(seed=13)
+    a = ExperimentAnalyzer(data=df, outcomes=["y"], treatment_col="treatment")
+    a.get_effects()
+    res = a.results
+    for col in ["n_units", "n_switchers", "pct_switchers", "fe_absorbed"]:
+        assert col not in res.columns
+
+
+def test_fe_diagnostic_columns_present_after_standard_columns():
+    """With fixed_effects, FE diagnostic columns are present and appear after the effect columns."""
+    df = analyzer_df(seed=14)
+    a = ExperimentAnalyzer(
+        data=df,
+        outcomes=["y"],
+        treatment_col="treatment",
+        regression_covariates=["cov"],
+        fixed_effects=["unit"],
+    )
+    a.get_effects()
+    res = a.results
+    for col in ["n_units", "n_switchers", "pct_switchers", "fe_absorbed"]:
+        assert col in res.columns
+    cols = list(res.columns)
+    assert cols.index("fe_absorbed") > cols.index("absolute_effect")
+    assert res.iloc[0]["fe_absorbed"] == "unit"

--- a/tests/test_fixed_effects.py
+++ b/tests/test_fixed_effects.py
@@ -109,3 +109,34 @@ def test_compute_relative_ci_false_nans_relative_bounds():
     assert np.isnan(out["rel_effect_upper"])
     assert np.isfinite(out["absolute_effect"])
     assert np.isfinite(out["standard_error"])
+
+
+def make_count_panel(n_units=60, n_periods=6, log_irr=0.3, seed=0):
+    rng = np.random.default_rng(seed)
+    rows = []
+    for u in range(n_units):
+        fe = rng.normal(0, 0.3)
+        for t in range(n_periods):
+            treat = int((u + t) % 2 == 0)
+            z = rng.normal()
+            mu = np.exp(0.2 + log_irr * treat + 0.1 * z + fe)
+            rows.append((u, t, treat, z, rng.poisson(mu)))
+    df = pd.DataFrame(rows, columns=["unit", "period", "treatment", "cov", "count"])
+    df["z_cov"] = (df["cov"] - df["cov"].mean()) / df["cov"].std()
+    return df
+
+
+def test_poisson_fe_recovers_irr():
+    df = make_count_panel(log_irr=0.3, seed=7)
+    out = est().fixed_effects_regression(
+        data=df,
+        outcome_variable="count",
+        fixed_effects=["unit"],
+        covariates=["cov"],
+        model_type="poisson",
+    )
+    assert out["model_type"] == "poisson"
+    assert out["effect_type"] == "log_rate_ratio"
+    assert out["incidence_rate_ratio"] == pytest.approx(np.exp(0.3), abs=0.25)
+    assert out["relative_effect"] == pytest.approx(out["incidence_rate_ratio"] - 1)
+    assert out["n_switchers"] == 60

--- a/tests/test_fixed_effects.py
+++ b/tests/test_fixed_effects.py
@@ -93,3 +93,19 @@ def test_clustered_vcov_differs_from_hetero():
     )
     assert hetero["absolute_effect"] == pytest.approx(clustered["absolute_effect"])
     assert hetero["standard_error"] != pytest.approx(clustered["standard_error"])
+
+
+def test_compute_relative_ci_false_nans_relative_bounds():
+    """compute_relative_ci=False (bootstrap path) NaNs relative bounds but keeps point/SE."""
+    df = make_panel(seed=7)
+    out = est().fixed_effects_regression(
+        data=df,
+        outcome_variable="y",
+        fixed_effects=["unit"],
+        covariates=["cov"],
+        compute_relative_ci=False,
+    )
+    assert np.isnan(out["rel_effect_lower"])
+    assert np.isnan(out["rel_effect_upper"])
+    assert np.isfinite(out["absolute_effect"])
+    assert np.isfinite(out["standard_error"])

--- a/tests/test_fixed_effects.py
+++ b/tests/test_fixed_effects.py
@@ -75,7 +75,8 @@ def test_relative_effect_is_control_mean_delta():
 def test_collinear_treatment_returns_nan_with_diagnostics():
     """Between-unit treatment is collinear with unit FE -> pyfixest drops it."""
     df = make_panel(seed=5, between_unit=True)
-    out = est().fixed_effects_regression(data=df, outcome_variable="y", fixed_effects=["unit"], covariates=["cov"])
+    with pytest.warns(UserWarning):
+        out = est().fixed_effects_regression(data=df, outcome_variable="y", fixed_effects=["unit"], covariates=["cov"])
     assert np.isnan(out["absolute_effect"])
     assert out["n_switchers"] == 0
     assert out["pct_switchers"] == 0.0
@@ -279,3 +280,45 @@ def test_fe_estimator_dropna_alignment():
     assert out["n_units"] == cleaned["unit"].nunique()
     expected_switchers = int((cleaned.groupby("unit")["treatment"].nunique() > 1).sum())
     assert out["n_switchers"] == expected_switchers
+
+
+def test_bootstrap_with_fe_keeps_analytic_se_and_warns(capsys):
+    """bootstrap=True + fixed_effects: FE rows keep analytic SE/p-value (no NaN), with a warning."""
+    df = analyzer_df(seed=21)
+    a = ExperimentAnalyzer(
+        data=df,
+        outcomes=["y"],
+        treatment_col="treatment",
+        regression_covariates=["cov"],
+        fixed_effects=["unit"],
+        bootstrap=True,
+    )
+    a.get_effects()
+    captured = capsys.readouterr()
+    res = a.results
+    row = res.iloc[0]
+    assert np.isfinite(row["standard_error"])
+    assert np.isfinite(row["pvalue"])
+    assert np.isfinite(row["absolute_effect"])
+    assert "fixed-effects" in captured.err.lower()
+
+
+def test_ols_fe_ci_matches_pyfixest_clustered():
+    """The df_resid coupling reproduces pyfixest's CI under CRV1 clustering too."""
+    df = make_panel(seed=22)
+    out = est().fixed_effects_regression(
+        data=df,
+        outcome_variable="y",
+        fixed_effects=["unit"],
+        covariates=["cov"],
+        cluster_col="unit",
+    )
+    fit = pf.feols("y ~ z_cov + treatment | unit", data=df, vcov={"CRV1": "unit"})
+    ci = fit.confint(alpha=0.05).loc["treatment"]
+    from scipy import stats
+
+    t_crit = stats.t.ppf(0.975, out["df_resid"])
+    lo = out["absolute_effect"] - t_crit * out["standard_error"]
+    hi = out["absolute_effect"] + t_crit * out["standard_error"]
+    assert lo == pytest.approx(float(ci.iloc[0]), abs=1e-6)
+    assert hi == pytest.approx(float(ci.iloc[1]), abs=1e-6)

--- a/tests/test_fixed_effects.py
+++ b/tests/test_fixed_effects.py
@@ -1,0 +1,95 @@
+import numpy as np
+import pandas as pd
+import pyfixest as pf
+import pytest
+
+from experiment_utils.estimators import Estimators
+
+
+def make_panel(n_units=60, n_periods=6, effect=1.5, seed=0, between_unit=False):
+    """Tiny within-unit panel. between_unit=True makes treatment constant per unit."""
+    rng = np.random.default_rng(seed)
+    rows = []
+    for u in range(n_units):
+        fe = rng.normal()
+        unit_treat = int(u % 2 == 0)
+        for t in range(n_periods):
+            treat = unit_treat if between_unit else int((u + t) % 2 == 0)
+            z = rng.normal()
+            y = 2.0 + effect * treat + 0.4 * z + fe + rng.normal(0, 1)
+            rows.append((u, t, treat, z, y))
+    df = pd.DataFrame(rows, columns=["unit", "period", "treatment", "cov", "y"])
+    # analyzer standardizes covariates to z_ before calling estimators
+    df["z_cov"] = (df["cov"] - df["cov"].mean()) / df["cov"].std()
+    return df
+
+
+def est():
+    return Estimators(treatment_col="treatment", alpha=0.05)
+
+
+def test_ols_fe_recovers_within_unit_effect():
+    df = make_panel(effect=1.5, seed=1)
+    out = est().fixed_effects_regression(data=df, outcome_variable="y", fixed_effects=["unit"], covariates=["cov"])
+    assert out["model_type"] == "ols"
+    assert out["effect_type"] == "mean_difference"
+    assert out["absolute_effect"] == pytest.approx(1.5, abs=0.25)
+
+
+def test_ols_fe_ci_matches_pyfixest_exactly():
+    """df_resid=float(fit._df_t) => analyzer's Wald reconstruction == pyfixest CI."""
+    df = make_panel(seed=2)
+    e = est()
+    out = e.fixed_effects_regression(data=df, outcome_variable="y", fixed_effects=["unit"], covariates=["cov"])
+    fit = pf.feols("y ~ z_cov + treatment | unit", data=df, vcov="hetero")
+    ci = fit.confint(alpha=0.05).loc["treatment"]
+    from scipy import stats
+
+    t_crit = stats.t.ppf(0.975, out["df_resid"])
+    lo = out["absolute_effect"] - t_crit * out["standard_error"]
+    hi = out["absolute_effect"] + t_crit * out["standard_error"]
+    assert lo == pytest.approx(float(ci.iloc[0]), abs=1e-6)
+    assert hi == pytest.approx(float(ci.iloc[1]), abs=1e-6)
+
+
+def test_switcher_diagnostics_exact():
+    df = make_panel(n_units=60, seed=3)  # within-unit => all units switch
+    out = est().fixed_effects_regression(data=df, outcome_variable="y", fixed_effects=["unit"], covariates=["cov"])
+    assert out["n_units"] == 60
+    assert out["n_switchers"] == 60
+    assert out["pct_switchers"] == 100.0
+    assert out["fe_absorbed"] == "unit"
+
+
+def test_relative_effect_is_control_mean_delta():
+    df = make_panel(seed=4)
+    out = est().fixed_effects_regression(data=df, outcome_variable="y", fixed_effects=["unit"], covariates=["cov"])
+    control_mean = df.loc[df["treatment"] == 0, "y"].mean()
+    assert out["control_value"] == pytest.approx(control_mean)
+    assert out["relative_effect"] == pytest.approx(out["absolute_effect"] / control_mean)
+    assert np.isnan(out["se_intercept"])
+    assert np.isnan(out["cov_coef_intercept"])
+
+
+def test_collinear_treatment_returns_nan_with_diagnostics():
+    """Between-unit treatment is collinear with unit FE -> pyfixest drops it."""
+    df = make_panel(seed=5, between_unit=True)
+    out = est().fixed_effects_regression(data=df, outcome_variable="y", fixed_effects=["unit"], covariates=["cov"])
+    assert np.isnan(out["absolute_effect"])
+    assert out["n_switchers"] == 0
+    assert out["pct_switchers"] == 0.0
+
+
+def test_clustered_vcov_differs_from_hetero():
+    df = make_panel(seed=6)
+    e = est()
+    hetero = e.fixed_effects_regression(data=df, outcome_variable="y", fixed_effects=["unit"], covariates=["cov"])
+    clustered = e.fixed_effects_regression(
+        data=df,
+        outcome_variable="y",
+        fixed_effects=["unit"],
+        covariates=["cov"],
+        cluster_col="unit",
+    )
+    assert hetero["absolute_effect"] == pytest.approx(clustered["absolute_effect"])
+    assert hetero["standard_error"] != pytest.approx(clustered["standard_error"])

--- a/uv.lock
+++ b/uv.lock
@@ -48,6 +48,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/85/ae/7f2031ea76140444b2453fa139041e5afd4a09fc5300cfefeb1103291f80/autograd-gamma-0.5.0.tar.gz", hash = "sha256:f27abb7b8bb9cffc8badcbf59f3fe44a9db39e124ecacf1992b6d952934ac9c4", size = 3952 }
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845 },
+]
+
+[[package]]
 name = "backports-tarfile"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -170,6 +179,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/96/392abd49b094d30b91d9fbda6a69519e95802250b777841cf3bda8fe136c/charset_normalizer-3.4.2-cp313-cp313-win32.whl", hash = "sha256:aaeeb6a479c7667fbe1099af9617c83aaca22182d6cf8c53966491a0f1b7ffb7", size = 98064 },
     { url = "https://files.pythonhosted.org/packages/e9/b0/0200da600134e001d91851ddc797809e2fe0ea72de90e09bec5a2fbdaccb/charset_normalizer-3.4.2-cp313-cp313-win_amd64.whl", hash = "sha256:aa6af9e7d59f9c12b33ae4e9450619cf2488e2bbe9b44030905877f0b2324980", size = 105641 },
     { url = "https://files.pythonhosted.org/packages/20/94/c5790835a017658cbfabd07f3bfb549140c3ac458cfc196323996b10095a/charset_normalizer-3.4.2-py3-none-any.whl", hash = "sha256:7f56930ab0abd1c45cd15be65cc741c28b1c9a34876ce8c17a2fa107810c0af0", size = 52626 },
+]
+
+[[package]]
+name = "click"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243 },
 ]
 
 [[package]]
@@ -381,7 +402,7 @@ wheels = [
 
 [[package]]
 name = "experiment-utils-pd"
-version = "0.5.16"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "lifelines" },
@@ -390,6 +411,7 @@ dependencies = [
     { name = "multiprocess" },
     { name = "numpy" },
     { name = "pandas" },
+    { name = "pyfixest" },
     { name = "scikit-learn" },
     { name = "scipy" },
     { name = "seaborn" },
@@ -417,6 +439,7 @@ requires-dist = [
     { name = "multiprocess", specifier = ">=0.70.14" },
     { name = "numpy", specifier = ">=1.21.5" },
     { name = "pandas", specifier = ">=2.3.1" },
+    { name = "pyfixest", specifier = ">=0.60.0" },
     { name = "scikit-learn", specifier = ">=1.5.2" },
     { name = "scipy", specifier = ">=1.9.1" },
     { name = "seaborn", specifier = ">=0.11.2" },
@@ -434,6 +457,18 @@ dev = [
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "ruff", specifier = ">=0.11.7" },
     { name = "twine", specifier = ">=6.1.0" },
+]
+
+[[package]]
+name = "faicons"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "htmltools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/e8/c12ef85c4444616ab1c1e96d5ecbadc8046d40b34797308846a2cfc06c80/faicons-0.2.2.tar.gz", hash = "sha256:6b7d7b19180179b6b83783f91bf6c9311c0f00ae0f97d41be1d24d9942361659", size = 604434 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/3c/1db1b0f878319bb227f35a0fca7cad64e1f528b518bcab1a708da305c86d/faicons-0.2.2-py3-none-any.whl", hash = "sha256:d45d7c2635b53582a3375c67d7e975a28a91d2c16ef5f6b5033b5cdd507224b6", size = 607225 },
 ]
 
 [[package]]
@@ -487,6 +522,38 @@ wheels = [
 ]
 
 [[package]]
+name = "great-tables"
+version = "0.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "faicons" },
+    { name = "htmltools" },
+    { name = "importlib-metadata" },
+    { name = "importlib-resources" },
+    { name = "multimark" },
+    { name = "nokap" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/be/3e35429e915bc355cc69f522d79ccc122858ae038738ca3dcd8a7d51c854/great_tables-0.22.0.tar.gz", hash = "sha256:ccf031d90cab599328232bc32afadef215da1457dbc025d0972048cc2050fd57", size = 26110797 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/46/0fd6ca17e3b40b657af79aaf50e2e54f736f4ad5585e201da702c52c7c2a/great_tables-0.22.0-py3-none-any.whl", hash = "sha256:7a7f81c2d1eb66d88166e864ac820966c23f04e4ecb41eeca8f9df1e1b21764d", size = 1455612 },
+]
+
+[[package]]
+name = "htmltools"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/54/e1a0ea0b8db8460fdedf584b4136a5b9e7f9d7072ee008f825f29b103660/htmltools-0.7.0.tar.gz", hash = "sha256:b95f922b7038f1b935ce24691ae74cb1ab9526d9c9cf1c2e2f329c38ef227a10", size = 105807 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/b2/bd9bfa6d77641bd3be57c7cd6ce10294d26db20cb9aedf19ac5d78845886/htmltools-0.7.0-py3-none-any.whl", hash = "sha256:92e5d06aeadb56e0ff63b236971bc58bb9cf6058c7235e3af57868e7bf113e1b", size = 89598 },
+]
+
+[[package]]
 name = "id"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -512,11 +579,20 @@ name = "importlib-metadata"
 version = "8.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.12'" },
+    { name = "zipp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/b0/36bd937216ec521246249be3bf9855081de4c5e06a0c9b4219dbeda50373/importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd", size = 27656 },
+]
+
+[[package]]
+name = "importlib-resources"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/06/b56dfa750b44e86157093bc8fca0ab81dccbf5260510de4eaf1cb69b5b99/importlib_resources-7.1.0.tar.gz", hash = "sha256:0722d4c6212489c530f2a145a34c0a7a3b4721bc96a15fada5930e2a0b760708", size = 44985 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl", hash = "sha256:1bd7b48b4088eddb2cd16382150bb515af0bd2c70128194392725f82ad2c96a1", size = 37232 },
 ]
 
 [[package]]
@@ -831,6 +907,125 @@ wheels = [
 ]
 
 [[package]]
+name = "lxml"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/3b/aab6728cae887456f409b4d75e8a01856e4f04bd510de38052a47768b680/lxml-6.1.1.tar.gz", hash = "sha256:ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40", size = 4197430 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/b0/83f481780d1548750b8ce2ec824073deef2f452d9cd1a6faff8507e3d16d/lxml-6.1.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:53b7d2b7a10b1c35c0a5e21e9224accf60c1bbfba523990732e521b2b73adef2", size = 8526461 },
+    { url = "https://files.pythonhosted.org/packages/b9/d5/30fa0f808002c7329397bfbb24e306789c0b29f04aa5842c07b174b4216f/lxml-6.1.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ff3f333630ab480244a1bff72043e511a91eb22e7595dead8653ee5612dd8f3d", size = 4595375 },
+    { url = "https://files.pythonhosted.org/packages/4f/d2/edb71cf0e561581a7c5eb2626244320eb04e9f8ce6d563184fd668b45073/lxml-6.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a4bbea04c97f6d78a48e3fbc1cb9116d2780b1b39e03a23f6eb9b603fd61f510", size = 4923654 },
+    { url = "https://files.pythonhosted.org/packages/4c/77/1bc7eeb0de4577d783fb625aa092cc9357883bba35845a3666bf1259f3dc/lxml-6.1.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db1d75f6617a49c1c01bc7023713e0ff59ab32c9579ae62a7674c0e34f3b0b0a", size = 5067921 },
+    { url = "https://files.pythonhosted.org/packages/1b/3c/c0690d74bd2bc17bc03b5b0d093569ead597dd0bfa088bf99eef8c24e19c/lxml-6.1.1-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a12689be69a28ddaa0ab99a5a1137da2afd5f8f16df7b5680b66f616d3eda1d", size = 5002456 },
+    { url = "https://files.pythonhosted.org/packages/66/8d/d1b3271af0c0f1e27e8472a849e4d2c65bc7766884b9ad2da9e76e145c88/lxml-6.1.1-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:18b73c339ae29b90fd2d06e58ebd555a751bde9cd6bbd36cc0281b9a2c94e9d8", size = 5202776 },
+    { url = "https://files.pythonhosted.org/packages/7a/45/689824ffb237fd10125ad273f32b28ff04dc6203c2822c85ff65a93df65e/lxml-6.1.1-cp311-cp311-manylinux_2_28_i686.whl", hash = "sha256:752d3bbfe874715ccd0aec7f88d7fc623c0f1fd7aa7b3238a084e017bad2a009", size = 5329945 },
+    { url = "https://files.pythonhosted.org/packages/5d/c0/ef73af53767e958fd87d437c170f272e2f6e6c0f854939f133a895f1e711/lxml-6.1.1-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:6b1761fbf9ec984e2e9d9c589ef5f5fd684b7c19f92aadd567a26c5224958db6", size = 4659237 },
+    { url = "https://files.pythonhosted.org/packages/a0/5e/e1158e40397585e91cb0472374a1f63d0926a1ddeaa92f13d1a1ffe306d5/lxml-6.1.1-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d680fbcb768404c601ecb43519ecd8461f6954cb11c06a78962f666832ccfca8", size = 5265904 },
+    { url = "https://files.pythonhosted.org/packages/a0/16/8687e5d1400ed1c0bc41dace232ebb7553952b618ea1f2e5fb6e2cfbbe23/lxml-6.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:162af1091cd785f2f27e62d3547ae9bc58ec5c86dd314d67021fd02463708d83", size = 5045225 },
+    { url = "https://files.pythonhosted.org/packages/ca/18/d877bd1ae2e5ffdfd4836565aba350db31feb2f2656d6ce70316ed66a05e/lxml-6.1.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:e9308ff8241c532df3f3e570f9a5aeed6c853f888512ba4b75638d7c11c95ef6", size = 4712721 },
+    { url = "https://files.pythonhosted.org/packages/44/4d/1f44fd1d770b10dacbf6b5c6e520f4d6e0708744930f719dc04e67cab981/lxml-6.1.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:5f6994074ebae6ffb04447268e37dc16edc304f9859cf91acb86e0af6c1b395c", size = 5252549 },
+    { url = "https://files.pythonhosted.org/packages/64/5d/1d66b84f850089254c230ef6ea6b267a5a54e2e179a5d960036a05d501d7/lxml-6.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:80c2dfadb855da477cf73373ad29a333535dedb9b12bad02c9814c8e2b43bf08", size = 5226877 },
+    { url = "https://files.pythonhosted.org/packages/ad/00/84c4b5302d42a2d0184f38d538c8a197f33b52a50bd4f7bcfe990bce3036/lxml-6.1.1-cp311-cp311-win32.whl", hash = "sha256:30a89d3ac8faec007453fb541f3f46807eeec88edd5826f6e3fe001752a2c621", size = 3594072 },
+    { url = "https://files.pythonhosted.org/packages/61/9d/2e2f7d876349f45e0f3e29f72da311668853d59b58d473a2dea4f0160135/lxml-6.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:abbefa31eee84842140f67acef1c828e28bba8bbf0c3bc6e5492a9af88152c28", size = 4025469 },
+    { url = "https://files.pythonhosted.org/packages/b0/d5/570e6390e4110331e6208b2ba83d1482cc9146808ee118b22824a34c1070/lxml-6.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:dcb292aa7fe485ceff7af4f92e46c5af397daec5dff64871a528f0fc47a3cc5b", size = 3667640 },
+    { url = "https://files.pythonhosted.org/packages/6a/6e/c4add832b6fc1e887125b96f880d7b9b70aae5248718e046b1704bcac4b9/lxml-6.1.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:104c09bda8d2a562824c0e319d0768ce26a779b7601e0931d33b09b53c392ef7", size = 8570821 },
+    { url = "https://files.pythonhosted.org/packages/22/00/ff3009c88e65de8011630acf8ab5a09cb2becd2aaf47fba2f3449f6224e9/lxml-6.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:25c6997a9a534e016695a0ba06b2f07945de682731ff01065b6d5a4474179da1", size = 4624252 },
+    { url = "https://files.pythonhosted.org/packages/42/95/bb63f0fd62e554fe078e1fb3c8fe9083c14ddc7ad7fa178d10e57e071ac7/lxml-6.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c921ba5c51e4e9f63b8b00267d06566e1f63407408a0496da2d1d0bfc819c7fc", size = 4930746 },
+    { url = "https://files.pythonhosted.org/packages/eb/99/0013e8d9b5960f4f041cf0b73e2f80c23eb5205b1f7bfb20203243651359/lxml-6.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:54a7f95e4de5fb94e2f9f4b9055c6ba33bf3d628fd77a1d647c5923caa2cdcdc", size = 5093723 },
+    { url = "https://files.pythonhosted.org/packages/29/91/317b332636bfc7bddcff828d41b3307f50043f4b237e40849c333d80fa1a/lxml-6.1.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f2ec43df44b1f76249ee0a615334f9b5b060e1c8bd90e706dad2d14d02f383", size = 5005557 },
+    { url = "https://files.pythonhosted.org/packages/42/2f/cc9bf06afe70f9c9093ae60855d9759da9db601ec4080f7473319666ffd7/lxml-6.1.1-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:70ef8a7e102a1508f8121aae5b0867abd663f72c14f0a9c937e6554cb4587b7b", size = 5631036 },
+    { url = "https://files.pythonhosted.org/packages/08/f6/af32e23e563971ffb0fb86be52bc5be5c2c118858ffc119bf6a9039b173d/lxml-6.1.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ebe6af670449830d6d9b752c256a983291c766a1365ba5d5460048f9e33a7818", size = 5240367 },
+    { url = "https://files.pythonhosted.org/packages/78/83/8555d40948b09ce86f1bd0c68a7ac31d07b1929f92cc1b074006c97ef2d2/lxml-6.1.1-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:27acc820660aaffa4f7c087f29120e12980f7779d56d8492d263170111284740", size = 5350171 },
+    { url = "https://files.pythonhosted.org/packages/63/75/5d92da93729b7bad783689e6496049fa40927b45bec7bf183c981de3ca70/lxml-6.1.1-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:1db753c9115ec7100d073b744d17e25e88a8f90f5c39b2f5dd878149af59671f", size = 4694874 },
+    { url = "https://files.pythonhosted.org/packages/c5/b5/3aad415a9a25b822e783f15deeb4dffccf5113030f1afa2222dd929313d9/lxml-6.1.1-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c4f469aebd783bb741c2ecb2a681008fd26bfe5c16a9a72ed5467f834e810df2", size = 5244492 },
+    { url = "https://files.pythonhosted.org/packages/f1/a1/5fcf7eb9904b80086aa47dcf0027de07b1bb990afad2e6823144c368ae04/lxml-6.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:766b010012d59470072c1816b5b6c69f1d243e5db36ea5968e94accf430a4635", size = 5048232 },
+    { url = "https://files.pythonhosted.org/packages/77/74/1f601b63c7a69fcdf10fa9b148c81da8442204194f6c55509cc485c786b9/lxml-6.1.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b8d812c6011c08b8111a15e54dd990b8923692d80adf35488bee34026c35accf", size = 4777023 },
+    { url = "https://files.pythonhosted.org/packages/a2/b9/7a78f51aec95b1bf780d78e12705a9f6533284f8693dc5c0e6724fa53d3f/lxml-6.1.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:fe0306bd29505a9177aac19f1877174b0e7422c222a59f70b2cd41633448c3dc", size = 5645773 },
+    { url = "https://files.pythonhosted.org/packages/a5/6e/98a7b7ad54e4e74fa1f20fff776913980619d0ebe5558232d7da6580bdd8/lxml-6.1.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:5ba186ad207446c65d3bb3d3e0412b032b1d9f595e59861e2354798c5703d955", size = 5233088 },
+    { url = "https://files.pythonhosted.org/packages/65/d1/bc0ed2427bf609f2ee10da303a6a226f9c8bce94f945dc29a32ce55de6e4/lxml-6.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:aa366a1e55b8ebfe8ca8ddc3cfe75c8ebade181aeb0f661d0cb05986b647f72a", size = 5260995 },
+    { url = "https://files.pythonhosted.org/packages/69/8b/6772e1a4b513fc50a8d931f19edde0e13ae6918510a1e13ff67864f3e5ed/lxml-6.1.1-cp312-cp312-win32.whl", hash = "sha256:126c93f7f56f0eda92f6d8c619edc463a4f23d9252f1c9d0405a76f25fa9f11a", size = 3596382 },
+    { url = "https://files.pythonhosted.org/packages/1b/89/45198e9624762af2dfd2cb8782598477ceb29f6e59caab560388ae1f4ec1/lxml-6.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:26e6eda8d38c1fcab1090dd196ee87cbd13788e531937610e2589085de074e77", size = 3997255 },
+    { url = "https://files.pythonhosted.org/packages/90/a9/7a54b6834088d9ae528a7b780584ba6a39a9457b0ac330479f20ffbc9449/lxml-6.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:6540377fbd53fe1b629172288c464fb18db11ce1fa7dc15891da10aa9dcc3e7f", size = 3659610 },
+    { url = "https://files.pythonhosted.org/packages/a5/eb/7e6f37c5584ccbb2ff267f56fd0339016938c1c8684cfefab9b33ffc2f36/lxml-6.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:68a9198d0fc122d14bb76837de9aa80cf84caed990b5b237f532ed87d3706736", size = 8559780 },
+    { url = "https://files.pythonhosted.org/packages/a1/36/587c2521cf23a2cd6c9c22108aa7528f683a1f195ed7ccd23a4b1786ad36/lxml-6.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7d47866cb32fb503450b6edc9df355d10dc49836af2e89901bd6ac6b0896d9d9", size = 4618006 },
+    { url = "https://files.pythonhosted.org/packages/6e/ca/ab7bfe2bf4c972af5e7878262845ead3a24a929a9b04bc11c7c1ece6c82a/lxml-6.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb7c9811bfaa8b1ed5ed319f5d370dfbcaa59d52ea64be2a5a85e18195930354", size = 4924139 },
+    { url = "https://files.pythonhosted.org/packages/6b/55/a0c72851dfee5ecc689f949723a73dea457758912542cb955b108eaf0d8f/lxml-6.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:762ff394d5bd56da0cf034a23dcce4e13923f15321a2adfa2ac00201dc6d3fca", size = 5082329 },
+    { url = "https://files.pythonhosted.org/packages/f0/b6/0608f7d61a3b96cc67e5648a3d906e31a5082093e10e7be65b3886289938/lxml-6.1.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a088f287f7d8275a33c07f2cac6c50b9319309a0200a39e7e75d80c707723099", size = 4993564 },
+    { url = "https://files.pythonhosted.org/packages/4c/66/ae227524b066d29d55bf0b453d93d2d793c40218657d643dcbbca13b8faf/lxml-6.1.1-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e902da4b04e6b52e5893900d4b8ab46068f75f3561f01bf1080957f9fd932ed6", size = 5613467 },
+    { url = "https://files.pythonhosted.org/packages/a6/76/dbe4a00b50385e40194231dcfe5a12c059de7cf90e89c83407d2b085b719/lxml-6.1.1-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1d4962d4c66bf830a7e59ed6cfc17d148149898a3aefa8ec6e59763e6e3ed085", size = 5228304 },
+    { url = "https://files.pythonhosted.org/packages/1c/01/00b1b8442ed2041793336868ba0b9ea4b13d7da7c085c6404c207a63bf79/lxml-6.1.1-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:581d4c8ae690a6609e64862dd6b7c2489635c2d13907fc2b20f2bc200ff1d21e", size = 5341607 },
+    { url = "https://files.pythonhosted.org/packages/63/36/1ad29931e9a4638bb707869f01d423a6c815f82152138d1a40dfcfde2b95/lxml-6.1.1-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:876e1ff5930ed8bf295ec5ef9a8155e9b6b1876bbf1deed8b3a8069311875a8f", size = 4700168 },
+    { url = "https://files.pythonhosted.org/packages/3c/d1/a9536cecf9be18a0dc72d32bead283a2332d1ffebd2dd3ac70ce444686e5/lxml-6.1.1-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9eb9b5a968f6e0f6d640092a567e14529ff8cea2e29d00da6f78a79fa49f013c", size = 5232487 },
+    { url = "https://files.pythonhosted.org/packages/0e/77/b4fb1e03bf5d130e879214d3100092e386418807fb74dd0adc4b0a48f351/lxml-6.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:aa49e06d94aba782c6a02eecb7e507969e7e7a41b267f1b359bb35585f295d5b", size = 5044231 },
+    { url = "https://files.pythonhosted.org/packages/26/4c/d00daeeb0a5530c4028a9232aa1b93db3ef4ed2158c116ea73c79a9765b3/lxml-6.1.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:70cdfd80589d59e43e18005dd7244e8895e93db8ab6a620b7e23df5445a4e3d2", size = 4769450 },
+    { url = "https://files.pythonhosted.org/packages/ed/6a/715a3a8d156ce42f29cf014706f5410c2ff3b02267774110fc23266409fe/lxml-6.1.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:aad9aa39483ed8ec44d6d2e59e5b98a0d80676ef0d92f44bfc374836111f62f5", size = 5635874 },
+    { url = "https://files.pythonhosted.org/packages/45/37/0544bc21dde2a88f3a17b504e6fc79c0e01d25a33c2f6079724e9e72b9c7/lxml-6.1.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:d49514be2f28d895c38cf9d2b72d7b9a07d00314519f456c0b50b53cfcf4c785", size = 5223987 },
+    { url = "https://files.pythonhosted.org/packages/4d/f8/f6a5e8185bcb28c2befae3d31f8e3df3b811cb0f47746517a81279fcafe1/lxml-6.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:47402e62c52ff5988c1e8c6c63177f5708bccf48e366dea4e3dcf1e645e04947", size = 5250276 },
+    { url = "https://files.pythonhosted.org/packages/c7/f2/1a2b9f1b7a49d45495369be7ef9ad05b262930f2eab3e3145706fca8083f/lxml-6.1.1-cp313-cp313-win32.whl", hash = "sha256:3483644525531e1d5762b0c44a8e18b6efba321b6dcf8a8952de10b037618bca", size = 3596903 },
+    { url = "https://files.pythonhosted.org/packages/e6/99/f4ffb024f238eec2131aaa09f3278fb6129cf892741bf68e1fc1afb8c100/lxml-6.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:a10bd2fd62e8ce916ececb342f348f190724a098c1faa056fdfb2a22ad5e8660", size = 3995869 },
+    { url = "https://files.pythonhosted.org/packages/d1/53/70eb8c5c6037f27448f1e3c54ebede9545a801ae63f0a7254afca4fe8e45/lxml-6.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:424aa57aca0897eb922aef34395bd1289b3b6f04e6bae20ea123c0c7e333cffc", size = 3658490 },
+    { url = "https://files.pythonhosted.org/packages/13/e2/2e325795566de01d0d7c3bb57d3c370616b2d07b01214e84eec5d3b10963/lxml-6.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:19b7ab10b210b0b3ad7985d9ac4eb66ab09a90b20fe6e2f7ba55d01a234345d0", size = 8577146 },
+    { url = "https://files.pythonhosted.org/packages/93/cf/5630b5e4be7d2e6bee8efe83865c925221103cf0221303b104ce134b01e2/lxml-6.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c08e5c694306507275f2290073350c4f32e383db15213b2c69e7ff39c1193840", size = 4623866 },
+    { url = "https://files.pythonhosted.org/packages/d2/51/3904907c063451cf8d4a5c9fe0cad95fa1f4ec57f4e3884fa0731bd7a305/lxml-6.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:74a9717fd0d82effef5c2854f0d917231d5324b5a3eb7275c43ac9fa32f97a14", size = 4950022 },
+    { url = "https://files.pythonhosted.org/packages/94/cd/9c7611a51c37a2830928405817cc5d56a97f64fab83cc3f628748b135749/lxml-6.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:efe0374196335f93b53269acd811b944f2e6bdc88e8894f214bd636455484909", size = 5086695 },
+    { url = "https://files.pythonhosted.org/packages/da/d6/24e3b5906abb0b674ff2ae195bc3ce59708df2bcd17cf17703b2d7dd643a/lxml-6.1.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac931cdc9442c1763b8a8f6cd62c0c938737eafc5be75eff88df55fc73bc0d00", size = 5031642 },
+    { url = "https://files.pythonhosted.org/packages/2d/db/6ec54f99019838bff54785c51da07f189eb4676861c5f2730962b0d8d665/lxml-6.1.1-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:aee395f5d0927f947758b4ec119fd5fc8ec71f07a1c5c52077b30b04c0fa6955", size = 5647338 },
+    { url = "https://files.pythonhosted.org/packages/42/3d/ef4dcfffd22d27a61805d8ed9f7fb888495bc6aa88648fa07c1eaa5586b6/lxml-6.1.1-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9395002973c827b3ed67db77e6ec09f092919a587022174554096a269378fb13", size = 5239528 },
+    { url = "https://files.pythonhosted.org/packages/62/bb/37fb3f0dff146bdcfa78eec47879273820b2a0bf350ec236ce14bd0b1c26/lxml-6.1.1-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:73bc2086f141224ebddb7fc5c6a36ca58b31b94b561e1dfe8e073e3270fad1e7", size = 5350730 },
+    { url = "https://files.pythonhosted.org/packages/90/42/43253f168388df4fae1f38c01df36ddb9bee39e2048167b54cdcbae85ea3/lxml-6.1.1-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3779def59032b81e44a5f70096ef6bf2082f8d901937dca354474ba09782e245", size = 4697530 },
+    { url = "https://files.pythonhosted.org/packages/eb/a8/c5a8504f81bbdfc8e7094c2c850cdb4ed6777fc4d5ddd9e5ab819f3b0d54/lxml-6.1.1-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:86c89b9d55ebf820ad7c90bc533410f0d098054f293351f10603c0c46ff598f5", size = 5250670 },
+    { url = "https://files.pythonhosted.org/packages/77/b7/c7e76ab18744d75e21f320ebf9ff9d1ceae2b54dd431ea5a64caf26c9672/lxml-6.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19607c6bbff2a44cf3fe8250abccd20942d3462473e0a721d01d379ed017e462", size = 5084485 },
+    { url = "https://files.pythonhosted.org/packages/31/31/b35c53f8ef7b7c31cacd23d3638652fff7bcd1deb6eedb709ab43b685908/lxml-6.1.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:c6ed5141a5c7507cf3ee76bd363b0d6f801e3321adc35b5d825a23115faa5465", size = 4737635 },
+    { url = "https://files.pythonhosted.org/packages/d9/06/31f23c813a7fe8e0cb1b175e915b08c9bf4e86d225b210feadbdbe519667/lxml-6.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:62aeb7e85b5d60320b9d77eef2e773994e2c0ce10121b277e0a19804e1654a5a", size = 5670681 },
+    { url = "https://files.pythonhosted.org/packages/1a/bc/ce619bccc89b1fd9ad8a8e1330ee3f3beff9f2ff95b712d7bbcdd6e22fc3/lxml-6.1.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b1b963fd8f5caa68e99dfae060d54de1fe9cba899b8718b44a00cdca53c3e590", size = 5238229 },
+    { url = "https://files.pythonhosted.org/packages/2f/5d/b329acbbedc0b619ebc2be6cf7ee9ed07e80892c88d4dfd612c33805789a/lxml-6.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:63876be28efefa04a1df615b46770e82042cce445cfdce55160522f57b231ccb", size = 5264191 },
+    { url = "https://files.pythonhosted.org/packages/d6/85/be36fb1425b30db3c3f9df75fe86343ebffb79e6320bd7f588e25bfeac39/lxml-6.1.1-cp314-cp314-win32.whl", hash = "sha256:7f7a92e8583f06b1fd49d01158143b8461cfcd135dcb10ec807270a3051bd603", size = 3657202 },
+    { url = "https://files.pythonhosted.org/packages/b8/ce/3cf9a827342269f54d405a6202397de63f07c69cbd6ce7d183a3f0cba1e9/lxml-6.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:b2d444f2e66624d68e9c6b211e28a76e22fff5fcabcfff4deac18b529b7d4137", size = 4064497 },
+    { url = "https://files.pythonhosted.org/packages/d9/3e/1a957bde8f0760039e627f94699f82caa782c9d838d86c3d28245ee67212/lxml-6.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:3fd9728a2735fda14f4e8235830c86b539e9661e849665bf926d3f867943b4bf", size = 3741991 },
+    { url = "https://files.pythonhosted.org/packages/78/b2/00ed55b3a2efa4658fb795c38d1090ec9b3e8a6c3683d4441fa517f09c3b/lxml-6.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:787b2496d0dbe8cd180984e8d29e3a6f76e7ea34db781cb3bd55e4ba1ef8b4ee", size = 8827545 },
+    { url = "https://files.pythonhosted.org/packages/c0/73/74573db19baa618d5f266f2407898b087ff6927115b00b71e5fc1b700847/lxml-6.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2c8daa471358dc2d6fcf02165e80ec68f77871a286df95bc5cc3816153b0fd2c", size = 4735736 },
+    { url = "https://files.pythonhosted.org/packages/16/02/6f7061f4f95f51e545d48e87647c54791d204a4e881be4156e7a26ba5338/lxml-6.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:acd7d70b64c0aae0c7922cca83d288a16f5f6da523637697872253415269baef", size = 4970291 },
+    { url = "https://files.pythonhosted.org/packages/b0/02/55fc057d8283427dea7d6edb102e7a840239c77a64a983d92f62a304c0e9/lxml-6.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4f0dd2f01f9f8a89f565d000e03abcf0a13d692a346c8d22f628d49af098777a", size = 5102822 },
+    { url = "https://files.pythonhosted.org/packages/e4/48/8e1cf78d89d66850121d9255a2a24414c98f775da93b90cf976956c24b14/lxml-6.1.1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b7e8a14c8634bf6f7a568634cb395305a6d964aeb5b7ee32248094bed3a7e2c", size = 5027923 },
+    { url = "https://files.pythonhosted.org/packages/ed/00/0632a0647612c8af24d26997b3b961397daa9d5b2581444805933629a4cb/lxml-6.1.1-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:86281fbdd6a8162756f8d603f37e3435bfa38043adb79c6dc6a2dfee065e7525", size = 5595843 },
+    { url = "https://files.pythonhosted.org/packages/bc/86/ab008a7dc360711b66858d61c80a5979a70a09f2aa2b05d9698df80b803d/lxml-6.1.1-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5d7152ec39ca7c402d8fb9bad86140a15b9503bd0c54484e3f1bbe3dd37ceca", size = 5224515 },
+    { url = "https://files.pythonhosted.org/packages/75/c6/2702ff375e728e34f56d9a45339a9cf7e4427e917f542225242d63a05afa/lxml-6.1.1-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:88d8cb75b9d82858497a5393e3c63cfbf03035225e4b35a49ed7ccb151e4dc0e", size = 5312511 },
+    { url = "https://files.pythonhosted.org/packages/b7/57/a5807c98f87a86f10ef9ffab35516df7c0f0c4b6d5d33e9f608ab9c04a31/lxml-6.1.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f64ec5397ea6a41fc1b4af0380d79b44a755b5531dcaccd9940fb260dca93038", size = 4639206 },
+    { url = "https://files.pythonhosted.org/packages/1f/e1/8a0a2c35734812395f4da4eaf33748a7e5705bfb2a58b128da764339d5ec/lxml-6.1.1-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d34bbf07dbc7ca5970671b1512e928991fb5e9d95365636c9b2d8b4f53af405e", size = 5232404 },
+    { url = "https://files.pythonhosted.org/packages/c2/e2/0e6a4dd5ad84d01d99aa7bae7cfefd4a760a0e0f8176818241de17d9b6c0/lxml-6.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:17e0e18d4ad8adbd0399291bc44845b69d9dd68439a3cdebdf35ff902ec05072", size = 5083769 },
+    { url = "https://files.pythonhosted.org/packages/a0/7e/161f33d463f6ffc1c7679104b65086dea120080d49dde4d238f015aaee2f/lxml-6.1.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:3ab541146f1f6968c462d6c2ac495148e8cdba2f8347700b2141b6ec5a75bf52", size = 4758936 },
+    { url = "https://files.pythonhosted.org/packages/f1/fb/2369825e3f6ca99305bf9f7b7085fda91c8b0922a89e54d900974aa3ef85/lxml-6.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2a0217714657e023ef4293500f65aa20fce6164c8fd6b08fa5bd4a859fb14b9b", size = 5620296 },
+    { url = "https://files.pythonhosted.org/packages/30/90/d61e383146f74c5ab683947ea14dc7b82778838ab9b95ea73a23b60d0191/lxml-6.1.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:05a82eb6e1530a64f26225b55cbd178113bd0b5af1c2b625f25e5296742c26d2", size = 5228598 },
+    { url = "https://files.pythonhosted.org/packages/76/2d/2dafd8149e94b05bb070690efd5bb2680720681e03ff03fc57d2b70a1105/lxml-6.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9e36f163528fc50cbef305f02a5fd66d404edf7049cdaff211dbc2cba5a7013e", size = 5247845 },
+    { url = "https://files.pythonhosted.org/packages/ce/68/b30e913340c380ddac9580c6e6230991fc37240ec4f64704833e4f3e2769/lxml-6.1.1-cp314-cp314t-win32.whl", hash = "sha256:649dda677cf3bd6ac9ae14007ba0c824ded8ce5808b53fc7431d9140399118c1", size = 3897345 },
+    { url = "https://files.pythonhosted.org/packages/3c/4e/9eb2af5335545f9fbcd7af57bcf87c6025d31eaa31b14ec184a6c8675328/lxml-6.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:793033d6c5cdf33a573f910d9bea14ef8f5771820411d118da8e1182edb53d5e", size = 4393350 },
+    { url = "https://files.pythonhosted.org/packages/7f/2c/0f1e93c636720e8a3eb59af2bfda99d98b55891e1c53bc30c2e0e865f01b/lxml-6.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:58bb955caba94e467d2a96da17660d2d704e0675894cba21ab8a775b8621fd1c", size = 3817223 },
+    { url = "https://files.pythonhosted.org/packages/b5/32/86a3f0f724a3a402d4627937a7fc27b160e45e7012b4adf47f6e1e844511/lxml-6.1.1-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:31033dc34636ea6b7d5cc11b1ddbda78a14de858ba9d3e1ed4b69a3085bc521e", size = 3930127 },
+    { url = "https://files.pythonhosted.org/packages/40/44/d832e82af08723761556d004b1d04d281c09f9a8cecd7d3148548c9941a3/lxml-6.1.1-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3893c14c4b6ac5b2d54ba8cf03e99fe5104e592de491f19bd6b82756c09f8004", size = 4210769 },
+    { url = "https://files.pythonhosted.org/packages/6d/39/0dc5949f759ed7d951e0bb8c2f2d9d7aca1908d22352fa84a8afd2ea54af/lxml-6.1.1-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c07da4cebf6889f03ebac8d238f62318e29f495de0aa18a51ea14e61ae907e2e", size = 4318163 },
+    { url = "https://files.pythonhosted.org/packages/e6/fb/8ab3845fe046ba4cbf74536bcf6801a774b7caf4350de1c5d37f1f0a9e90/lxml-6.1.1-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6f0ce10945fab9c4c06ce14e22af9059d1a87493a9af4501a5b0b9187e21cf2", size = 4250945 },
+    { url = "https://files.pythonhosted.org/packages/68/1b/7553ab136894374ffae8851ec06f98f511cd8e66246e41b6be059d0a7289/lxml-6.1.1-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f8844cd288697c6425c9beba919302241e3278871dc6519515e72b04e987abcf", size = 4401664 },
+    { url = "https://files.pythonhosted.org/packages/db/a4/441aee36c6f6b249823d20fd91f9be9ab89d7c5a8ae542a4a4ca6d342d56/lxml-6.1.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:ed21202aec73cda4d55d1ce57b389aadb90ffb044e6cd1080b8347efe1b1ec84", size = 3508989 },
+]
+
+[[package]]
+name = "maketables"
+version = "0.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "great-tables" },
+    { name = "ipython" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "python-docx" },
+    { name = "tabulate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/70/82a24141e18b25b1c70ad3b8389f28c3d49a56f289be4b0247977a7202d1/maketables-0.1.8.tar.gz", hash = "sha256:aa4b3776fd9bac6d6f881866824e6a13b9e647f8c87f234d9a24463242ad19f1", size = 69225 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/cb/7ef3503279a4d2dc6b7fed0d0c53a9d97d98f7c28166ebfcc45eef64fe29/maketables-0.1.8-py3-none-any.whl", hash = "sha256:d79aeb0c08ae8ed7d78978b5676ff1a5236517abbbd287b04986602504b0bfb5", size = 72305 },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -916,6 +1111,33 @@ wheels = [
 ]
 
 [[package]]
+name = "multimark"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/6a/9e3029b89074f2ce705dd1a94eaf1372a49ac63ac47712a0f2410c574add/multimark-0.2.0.tar.gz", hash = "sha256:15a53111c52e0a65c200b57a5068a618734af52fc5d6512e8b9884fadbb2b8b8", size = 436111 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/65/c080aa324ea650b78c7396a26395b0e8bbc7ace40651c3c9929e5222da85/multimark-0.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:483f51c416fa8a83cfe430b020afcdd08fa8e33a1335851c8ec9f617f9c561c7", size = 132784 },
+    { url = "https://files.pythonhosted.org/packages/8e/1e/d69bf6d93ad964e8d3efce6904c609eb4733f8bcfee33ceddb838a6e52df/multimark-0.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cf194a957dfeccb1d9d6cf38b787762c377895fdebbe9064533c6c1b13c65dd1", size = 130431 },
+    { url = "https://files.pythonhosted.org/packages/dc/fc/65505a111b35dcc0fccac6fc880e7b1d957606c8ead1d7792d6d292f2090/multimark-0.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8dd2ec35a273afe6a8f3101b4db1f850488c1be1af9525be53150129baf956db", size = 450398 },
+    { url = "https://files.pythonhosted.org/packages/00/42/346e9d7a49acde3240cde23492467c69b6f749ea932c0135dc490bc16cd4/multimark-0.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e05fe7c1badd7648e869eb5a65153d9d0b5dfbcdfaae795caaf0b77fbf92da73", size = 452478 },
+    { url = "https://files.pythonhosted.org/packages/0d/2d/e93c35a182373a9fbf56b78464372f9f909271ac65d879af51c0a6bc4b45/multimark-0.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:54cecb32ad96ca8672e320adc537c462807ca0bf9a3a421b68fba93c9708d5b1", size = 124924 },
+    { url = "https://files.pythonhosted.org/packages/c6/ee/b016667bcdb49630c8536146084d2726393c3123844021d18f559ac60145/multimark-0.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4be13eebff92579dfedda2d976e2d7cc6c4e1fd7d26c9b0a5a92de48f941146b", size = 132971 },
+    { url = "https://files.pythonhosted.org/packages/8c/ed/be18fa30222de97e206e1e3d4e4bd425a3c21dfe22b5650a81e015548c80/multimark-0.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:77ce50f531536f97007e090895327552f1a4a9847129f34f5afb6d6f8e00bce7", size = 130481 },
+    { url = "https://files.pythonhosted.org/packages/33/50/c5fbecf55ff3c05133d062653b22e63a14fa1a9bc890ac759d8826a48f36/multimark-0.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f093afd5696e58207bbc10854005f9f0ef4e34874437d266e53ed1b819f2cff", size = 451011 },
+    { url = "https://files.pythonhosted.org/packages/90/be/ae21b6d68eb6674086a60720c4d54367f4ef2ce963f33177f3710bdac9f6/multimark-0.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4498fea15ca97c578982f349d2521cd45895409e9d000f285e410ff0b82915af", size = 452975 },
+    { url = "https://files.pythonhosted.org/packages/28/85/0f361fa06cfaf62758fefef2d11141bbc58672a2c9d625674891b93fc23b/multimark-0.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:ce9daae00ddc4f0f0cf07482d71b4f2bc95fac5aa81e8b3084252a8a23427dc3", size = 124934 },
+    { url = "https://files.pythonhosted.org/packages/36/75/0759e525cd4b53eeaa6b53b819d630fd2b1c5b73e6561e6b83a16a3ea4fc/multimark-0.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:390941f897850a4347d61fb4d8890810adc0c964a7d4565fc77c4cf30c0b5ea0", size = 132975 },
+    { url = "https://files.pythonhosted.org/packages/e4/f7/33f0c8b6814b2e034956df0bdb971fb64d88277fd1ddbf71ea5e135823f7/multimark-0.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1a8527fe99aa56089228fe132540398c908e179a2a2259f4da006d5f6aab7217", size = 130476 },
+    { url = "https://files.pythonhosted.org/packages/fd/08/e6b1816b4ca68bf20a72f4784d924b12fe96083c0edbd4dc2e52e1795920/multimark-0.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5b0bb3060b3a4b050bd1c6c75bbcbc8d0e705a70af73d3269c9637a2f4e08123", size = 450977 },
+    { url = "https://files.pythonhosted.org/packages/c4/4b/a5acdb28bc9e8ee638d8af74938780188efd5ae0102928ee33cd508cba72/multimark-0.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9b5542fee4d73498e3bc1055375a1370d6ca72916804a7c8484fa4409fd635b6", size = 452983 },
+    { url = "https://files.pythonhosted.org/packages/7f/65/8c550c71d1dc79ba04de57177a11e809b8a27ac4e56726ec487dccd68c95/multimark-0.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:c3ff54935aa0724390955c12a91d85d4e04664c2c8da147714226a4ac905b387", size = 124938 },
+]
+
+[[package]]
 name = "multiprocess"
 version = "0.70.18"
 source = { registry = "https://pypi.org/simple" }
@@ -976,6 +1198,15 @@ wheels = [
 ]
 
 [[package]]
+name = "narwhals"
+version = "2.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/3c/c4ef2164a71c1a63d7f1ae411c4082c5fa872405106db60a4b7114989ad7/narwhals-2.22.1.tar.gz", hash = "sha256:d62920805a0a43b7ff8b54b0c0d3142d796f8a9301836ada37e573d6a33cbcd9", size = 647493 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/ca/36339329c4604adbcc99c899b7eb1ce1a555c499b6a6860757dc9bfed36d/narwhals-2.22.1-py3-none-any.whl", hash = "sha256:60567d774edf77db53906f89d9fbd164e66e56d66d388e1e6990f17ac33cfb53", size = 454815 },
+]
+
+[[package]]
 name = "nest-asyncio"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1015,6 +1246,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/50/76936ec021fe1f3270c03278b8af5f2079038116b5d0bfe8538ffe699d69/nh3-0.3.0-cp38-abi3-win32.whl", hash = "sha256:6d68fa277b4a3cf04e5c4b84dd0c6149ff7d56c12b3e3fab304c525b850f613d", size = 599000 },
     { url = "https://files.pythonhosted.org/packages/8c/ae/324b165d904dc1672eee5f5661c0a68d4bab5b59fbb07afb6d8d19a30b45/nh3-0.3.0-cp38-abi3-win_amd64.whl", hash = "sha256:bae63772408fd63ad836ec569a7c8f444dd32863d0c67f6e0b25ebbd606afa95", size = 604530 },
     { url = "https://files.pythonhosted.org/packages/5b/76/3165e84e5266d146d967a6cc784ff2fbf6ddd00985a55ec006b72bc39d5d/nh3-0.3.0-cp38-abi3-win_arm64.whl", hash = "sha256:d97d3efd61404af7e5721a0e74d81cdbfc6e5f97e11e731bb6d090e30a7b62b2", size = 585971 },
+]
+
+[[package]]
+name = "nokap"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/f7/a4f3d6f89773df40884bc10790977c80a9ea17ad526ea0b0cd35a703595c/nokap-0.1.0.tar.gz", hash = "sha256:63071cf5e7c4f0487532f6281c6ea85d90673d5cd835ffe5e64c913989742eb9", size = 77047 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/dc/c35af5ccf8dbf3268750c54a3c0830f486b8faec38c811aff92335aa99ba/nokap-0.1.0-py3-none-any.whl", hash = "sha256:36f2cae8d4251945dbe311ef68916c7eddfe51da490aabe0d68c5d13294b2539", size = 36233 },
 ]
 
 [[package]]
@@ -1289,6 +1533,105 @@ wheels = [
 ]
 
 [[package]]
+name = "pyfixest"
+version = "0.60.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "formulaic" },
+    { name = "joblib" },
+    { name = "maketables" },
+    { name = "narwhals" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "scipy" },
+    { name = "seaborn" },
+    { name = "tabulate" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/68/61b5e117fa0b0ac3ef17e2dde4722ea6b3b1218020661fedc312087e59cd/pyfixest-0.60.0.tar.gz", hash = "sha256:ec4f4759b5b53c19aaf6ea81ddc745d57c7c8c5577f8d859a2fc9ca2c73e3aa7", size = 2610121 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/47/54b7fc18917b50d58a85e1cfefd4da7de8e00a0ec7e84438170d04838fd1/pyfixest-0.60.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:f2eda76750d376ced2715cb2a69fb26e09da2ad35b22e7162c1f31a5f57feefd", size = 2973584 },
+    { url = "https://files.pythonhosted.org/packages/89/b0/32e803870d50937dd1f4d5b4a8cf2acf960757fa4612131e76d77d550ec6/pyfixest-0.60.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:92b9b42327e1c40ec68fa0b33cbc021ec950c81a6f4e6f01a6f2f307e6cbdfab", size = 2815853 },
+    { url = "https://files.pythonhosted.org/packages/47/77/77ff01a1061f80a09afcc008005f0e1b83484a25a85aadaf9d19b9fc872c/pyfixest-0.60.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:482d391f498fc1c386552c2c767460311a78a5a9607b6a3a4ed89973bd75ba28", size = 2906607 },
+    { url = "https://files.pythonhosted.org/packages/26/c9/b743a7e136a9a954688c509602e3ba1ebcbf98647b79a689a545d3c830c1/pyfixest-0.60.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a867180214de8b27b81baccb666a9943ea5f73e48f81b147a69bdbed0b0fe34f", size = 2806016 },
+    { url = "https://files.pythonhosted.org/packages/da/c4/aa01ec0f68530fa564f4663e4a772cdc85e8944470c78c635ce6c37318aa/pyfixest-0.60.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8a892d90e4aac5f8b525d1f7aec6083798e29e6d672274fc0cb99426b4a3c202", size = 2985499 },
+    { url = "https://files.pythonhosted.org/packages/de/f9/c99a77b82f930e421f005c325dbc11b619bc7afa2530611d7307651bc410/pyfixest-0.60.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:133dbef0270628e9277125c90759fb92b6f1dc1559754aca926d81ea2be820ae", size = 2952408 },
+    { url = "https://files.pythonhosted.org/packages/a9/1a/d89f9adb7a45e2283498bcf7c0a9524310e94f9f704474e7e111e349c78e/pyfixest-0.60.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8b0b1ab12b2d91984d544b723b53bf11cf03fcb80ed4c33957be8309799ca83d", size = 2921888 },
+    { url = "https://files.pythonhosted.org/packages/6b/26/978ed03515cd2739f6731940c98a00dd5c3e0956b47c5d1e845269c86112/pyfixest-0.60.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cb4d4b4730ce2b751601ea9c48df945e26e2dd71e786a1e54d186497ce681355", size = 3267651 },
+    { url = "https://files.pythonhosted.org/packages/0f/30/fe5ff1af9a5fa3e5f5ef50b98f9ce5237d9044ae1651ad15cb9a77af2eb6/pyfixest-0.60.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:11f3b89ffcff61ae6ea95009e74d380c4b9c858f0a0e39bac972fa7b3308bd11", size = 3083489 },
+    { url = "https://files.pythonhosted.org/packages/f1/43/3bb5d1ede3f6d06f0d5b15cd7b75124d646578e9c10ee9cf309688dd554c/pyfixest-0.60.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:7c90dad21e1f35cb46a3aed03ce40a0a59b7e24c54a2188d967319d5cea925f9", size = 3080916 },
+    { url = "https://files.pythonhosted.org/packages/9d/c3/039754a3d442d6a75a143b04058e41e0446ee53694c6085e1c77a5b44681/pyfixest-0.60.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:3a7a2922b8686765edb159fa78e57a3578e8cede2df1387233bcec4945127b09", size = 3187109 },
+    { url = "https://files.pythonhosted.org/packages/f6/59/1c46bc8145521e45e16d194141a39f47efd4d64bd7d70122663d03633a9a/pyfixest-0.60.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ff1a0aff2a2d6ad04c75728aa212ddc69e67575e2f5a4572b58c1680eeb6627d", size = 3480735 },
+    { url = "https://files.pythonhosted.org/packages/9c/2f/641cb0eb7945b81c546d7cc4b0749d2151180ceebffdfd9e67904c2e48e6/pyfixest-0.60.0-cp311-cp311-win_amd64.whl", hash = "sha256:dd8d36846418c572040103c94bd65070fe76576b81a00f9224bbaa34e9dee137", size = 3111021 },
+    { url = "https://files.pythonhosted.org/packages/0f/26/6dd0eccad8e21b0a35a46c6b8ee0c75c77b9b6940ff98c4de3e68d8f07b0/pyfixest-0.60.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a7f9e5088e850393860c3f7c3d6659e92b6091355c8cb07888485177ea6607b0", size = 2974246 },
+    { url = "https://files.pythonhosted.org/packages/6f/12/0ab3920643f52eb21271b952b79998b374bf2e68a651f5201b4ac8aa044e/pyfixest-0.60.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:78c924713d597c28fd55193ed327022140ce3f911777695fad84ab35e17878e1", size = 2815479 },
+    { url = "https://files.pythonhosted.org/packages/98/45/f5d4953e1cdb285116f7313c69895acc712a281b9b2e470b62ead6711f01/pyfixest-0.60.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b3a82bf756bfaff35a015fc49bd51e9c0573618c9caa21be6aabb51dcc7ae0fc", size = 2904873 },
+    { url = "https://files.pythonhosted.org/packages/72/36/c50bf278683fb7c9d25b3db8b50ccc88b1d84c41b41c74a0a563554334f4/pyfixest-0.60.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4c0af86e9838880f517c5338d4dbe936baaaea8f325a4fd038b4b9adae43661e", size = 2804910 },
+    { url = "https://files.pythonhosted.org/packages/47/73/493fcdd9c73a73aa8ee5022a38889903684b7135076b16e35846a786d034/pyfixest-0.60.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:207467f1fb77611895cc98feecf7c4f626695468cdb5acd8203525331fb795bd", size = 2985504 },
+    { url = "https://files.pythonhosted.org/packages/be/7c/0695445ce9e026471fba162b80957db91d9ca2c761db685094e7ecdccc41/pyfixest-0.60.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5aecb2724584e2c8920ffb31eeeecee230877abba2ef04e229143f2d926e319c", size = 2950269 },
+    { url = "https://files.pythonhosted.org/packages/0f/4c/44f3b35165c92daaf2599285ec86b35e2c2277682fe316489b525ea5ab30/pyfixest-0.60.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fccedfd401d7170deabf84844f3221c59576b29b848d7da7cde11cbb34775952", size = 2920713 },
+    { url = "https://files.pythonhosted.org/packages/87/4a/74d5c8ef7bc1677b5aec3b5f353b0c51917e79ee6d12d7cb7cf4ed4fb0f0/pyfixest-0.60.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d14c4f41a54534cbbd448e6dd87e9ec9dbe5ae79c15fed8c37e3f0eee58b349f", size = 3266112 },
+    { url = "https://files.pythonhosted.org/packages/66/58/1e0f390e1c6e1941d5e788949e68e4dcda867225a003c3505a7920565934/pyfixest-0.60.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ea32fa51853cb94ecea2794415e0cbb8b09604a4bb2c0b087b7a671c2b2415ff", size = 3081283 },
+    { url = "https://files.pythonhosted.org/packages/92/65/ee40a9b5bc4dee8186cb042e21d44166fca6709214d0359100164cbaeeaf/pyfixest-0.60.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:fdcf94771ab9857c48c8344d3316863dccc77e4b8d4bdbf4f08caa6a33e4076a", size = 3079962 },
+    { url = "https://files.pythonhosted.org/packages/d1/23/257dc5945b1c79af96e26df6812ac85c08cb89f532b27e821e080ac1e9b7/pyfixest-0.60.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:90b854d094602aa3435e8b2b2ecfeb6e00acc0047c60a7e902316c7dbd05b67f", size = 3187237 },
+    { url = "https://files.pythonhosted.org/packages/88/02/d426260c082b60bc309536c7ea605eada90c63bcd2f8f37757460d2abb33/pyfixest-0.60.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ce065d81f948cdeab2ec2add92d25dc603c112b7630106128e9c3fc450be4458", size = 3479201 },
+    { url = "https://files.pythonhosted.org/packages/e9/27/cbb72acb991867ff61394895ca1652dcd4c4a0ec14f4f8fb0ac8a3f5a0b3/pyfixest-0.60.0-cp312-cp312-win_amd64.whl", hash = "sha256:ad2498711231f0d1457ae14351c68f7cd87dfb5f4da63737ad945a9ab03c1efd", size = 3109335 },
+    { url = "https://files.pythonhosted.org/packages/4e/82/f95e7940605e5fb5c70ecc99811b5a0a51bcd7f3ada31a8a07a77b209ba4/pyfixest-0.60.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:4c7641f275757fd9fc93aa351c49e91161d0b51e87454b55a55559163375492c", size = 2974086 },
+    { url = "https://files.pythonhosted.org/packages/5c/7e/e25287af81526d7b48c7f211e301702f9f95c1616b9542c1506f3cdc8047/pyfixest-0.60.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b5ae48bbf1e6f2c280502fe64134eeed80cdc298179b64e1b37d277fc15350e1", size = 2815386 },
+    { url = "https://files.pythonhosted.org/packages/a2/54/9be263ecbd12de2f2fe16dca06763e1ac5958112cb637ee1c3a6fa2ab5b9/pyfixest-0.60.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69dc3884a9a81a251ae774fcbf46916898a8f16e4debda98a929cd2a813e45c3", size = 2904732 },
+    { url = "https://files.pythonhosted.org/packages/81/f5/b2526e0bbea735365f49cbb06f0d3be4d6d536b5fd1aa0eee5f212f22930/pyfixest-0.60.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c78ff45e7c6ec634d2e068bd52c8af9561db7811460e2ed4f33880aade30fc33", size = 2804798 },
+    { url = "https://files.pythonhosted.org/packages/49/2f/34fb473335c289e6b863c7f36d56a2db5fa763ff378081448ef265c1c375/pyfixest-0.60.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae999817c1d41e363c1c3f7518f4e905195a61e05ac830b66b64832594fae064", size = 2985541 },
+    { url = "https://files.pythonhosted.org/packages/de/b0/854d3f5560772b85f31cf2a58feaaaeca57ccd59207d4702375fdf7d20c0/pyfixest-0.60.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:887f92a88daa7c07565e3edd0cf9dece3a5d39b3295d5f8f4990a605fd670434", size = 2950230 },
+    { url = "https://files.pythonhosted.org/packages/53/cf/44dddf62697f9649f00d7c1451d244193dfeb1eac6ea395fcf1a92ae95ec/pyfixest-0.60.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d64f5e9e82cc27bbe37a0d1a85145cccf1118ef38705b1b32cd1bf7247a27e51", size = 2920627 },
+    { url = "https://files.pythonhosted.org/packages/25/1b/3737c3e66ff06650f0a2ec6149bef21ef6961c5fcc1d76850ddb5af1f01e/pyfixest-0.60.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1fe12537c01b72874748e1326e33b8c96e3dac498a57bf519bf20e240ee77b7", size = 3265880 },
+    { url = "https://files.pythonhosted.org/packages/fe/03/41f24c85143df27f0684207eb695beb0630086bde293c1fe0dea27131e96/pyfixest-0.60.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:07db7d6a6a72b91ab24c24994707f4f792a03bf86debea5ffcbb7ffa4f302583", size = 3081216 },
+    { url = "https://files.pythonhosted.org/packages/b4/92/01f9750ce22d6fa32cd58f3465f30ce7656fd5f86a5b0bae4ddacad5a064/pyfixest-0.60.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:723dd07d7826ea2703ac1829a2a5305114f979a5bb5a5eebe799603a9bb17a2c", size = 3079948 },
+    { url = "https://files.pythonhosted.org/packages/c4/83/0dde250c3d45f6b3d908d647409fc199d624dcb948c6b8edc1a7ce4b46dc/pyfixest-0.60.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2807c8655713e6219468db72d627ec226ab5b62fc355a1918b2c424c91d2eb46", size = 3187173 },
+    { url = "https://files.pythonhosted.org/packages/57/7c/ad0062dd6acd97cc1eca3cb241f9244781ef1e767a6f72ec769ba88b74aa/pyfixest-0.60.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f2ad65ff560a94d0c3ad7b42f278de6ba723c62af6bf2d549b7f10cd8a8ab07f", size = 3478973 },
+    { url = "https://files.pythonhosted.org/packages/dc/f0/2938e4f00f8553a81d50f0f2f8b7cefb7475b73520a5f858919ac11708c5/pyfixest-0.60.0-cp313-cp313-win_amd64.whl", hash = "sha256:1ab01111be3b5bdc7ebec5123c2ac91be53c7981082c5cbd33cc3528102d8ad4", size = 3109275 },
+    { url = "https://files.pythonhosted.org/packages/c5/6d/e793b5547d49ca6fa3c208fe4d0d90f9fd0c58624ba521401274fdd4e4d1/pyfixest-0.60.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bbf9695aa68256a7e175176674b24e18da4b5341ad62bab9f1cac2af8df39ecb", size = 2903507 },
+    { url = "https://files.pythonhosted.org/packages/19/33/c66f15bf9c5ab71298ee3c243beb7b10676469ffee8f7a3ab3c853410c1b/pyfixest-0.60.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:769563ae478914cab77c8b2eab5c745438ed09c171c3c4bed38e923b2edef272", size = 2803365 },
+    { url = "https://files.pythonhosted.org/packages/a2/88/f0a32fa8dcf398dd0997313acb79c85c28b5f86c0a2a379d11841379bf38/pyfixest-0.60.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:411e75df8e71757ba17550a81704b6c667b263768b92933a7ad8be475be02299", size = 2949250 },
+    { url = "https://files.pythonhosted.org/packages/17/9a/641d1e7c84914cf1fcb3df1ebbc53a57ae499707d7e4bb8cfedbff7c0c4d/pyfixest-0.60.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:13867add7167e65549836c252d72f0593a4e31981dfb33a6c683ce958a1c854f", size = 2919272 },
+    { url = "https://files.pythonhosted.org/packages/b8/71/1f8e11a08b990e8efe33e8c2a3e02355c577cbfedb494ad0dd91f13aeb34/pyfixest-0.60.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5c6b9e639c916675b321fcedcc7e3b7db668dbb7d7a2863fa0a174496269906c", size = 3079854 },
+    { url = "https://files.pythonhosted.org/packages/c3/4f/80b2d9459c76a42a60848877160bf985c3b6d82dba20083b3920742f59de/pyfixest-0.60.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:89797195a2f0b512be387b4ca5ad57e2af4176f701d1d2d4845522ced3fcc613", size = 3078673 },
+    { url = "https://files.pythonhosted.org/packages/ed/14/0492d107568a93eab78cc30ef4d77440654e448954a926c8be10c9d4e267/pyfixest-0.60.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:bbb7614caa7db53df225fe34557270aba7da2d836e677bf284bf411a17205145", size = 3186002 },
+    { url = "https://files.pythonhosted.org/packages/0e/db/3f930ad36260654e595b120224bcac3d76876c6292160fc526c284ab14dd/pyfixest-0.60.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:649051e8e4b778ef1a7930707d6720c0555b5abcf9403f872378456e46013d9a", size = 3478470 },
+    { url = "https://files.pythonhosted.org/packages/38/b2/70e856af947f1c4d581adbf4617a165a1350b90e9fed52b329859d170eeb/pyfixest-0.60.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c4b35fe319486f81bd6e350bacadc6e366316654ae81b78df024ff810afe0e2a", size = 2974227 },
+    { url = "https://files.pythonhosted.org/packages/c1/e6/421940d8114487590a4a587b45db9652fc0280a8a62365076a2cdb148f76/pyfixest-0.60.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c76e98f375a4eafebcc27bf504b1f4d7e97bc2e207a9be7c8c0a4d06d0514d38", size = 2815388 },
+    { url = "https://files.pythonhosted.org/packages/f9/9f/cca860b2e5f5878c7bde39a7e853d60a03f9bbf395165ec051ce5dba6113/pyfixest-0.60.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e3a77b1f7d59361b5b31ceae306e5fd27382ca2df6dd6ece7aa08e7062ec9aca", size = 2905260 },
+    { url = "https://files.pythonhosted.org/packages/ec/6f/7758e2ec46c50aab30c70d9c1e7653d52ae925f2ded2c2bd063c4434ca86/pyfixest-0.60.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:91bcbbf45f2944a683f6a0edb965e37e8416bdfe8dabf59101df46f3bbd751cf", size = 2804867 },
+    { url = "https://files.pythonhosted.org/packages/e0/d3/ba0f32e8843638968a95c6f05b2b1b2b5825c91d2bec63b7320373ade927/pyfixest-0.60.0-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3b75e71e79faba105c571c28dc196304ce62b9585a0416422ce08220ebdd640f", size = 2985908 },
+    { url = "https://files.pythonhosted.org/packages/b9/3d/afac4c415a71d4d44fcbcdf346c77b7c567ee1f9b3c296f50f26added3a5/pyfixest-0.60.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:878e68d3f3086ccdf00135b047e8a9ea57aec80521c8321aa86d632091196102", size = 2950322 },
+    { url = "https://files.pythonhosted.org/packages/2d/54/9d762ee81ef883344c8702151f5f5da6d8bfe8089064abb783fce09b527f/pyfixest-0.60.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:938e6895c24cdf42c02a3a2d1596a15fbe4c22ca85237c55616ca0b1a5154fdc", size = 2920931 },
+    { url = "https://files.pythonhosted.org/packages/3b/9c/7dc5f66ad5e1938b84fc52295228c115c63076c11cd49cd03b6d2010907b/pyfixest-0.60.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:571b3eba93ba5fd1de9d9ee8650dcd31400e7d15a243f6f9f22b7a9e9f280e08", size = 3266159 },
+    { url = "https://files.pythonhosted.org/packages/ea/5b/c401c1d3790d58cdca116860b6128cabdb5df6733699924a096686af74fc/pyfixest-0.60.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:14ab333b365dcf8f816a7dfd880736d990ac47833a1b0fc6a128569cf925d332", size = 3081776 },
+    { url = "https://files.pythonhosted.org/packages/b3/8f/a3d3dfeddd93083432d090bbb2c118302c0a934a7e7c6358e96ec5b46171/pyfixest-0.60.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:0acb2b42da6b6fa34c7bf5be9ec5c6b7de2e6e81d1aeaf5387cbb40930e567ad", size = 3080229 },
+    { url = "https://files.pythonhosted.org/packages/b3/47/86efe92bcc4c8ba11dbb098b60b0dd61216845525dcf70e43488bf2788a8/pyfixest-0.60.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:d7944e87dd78191741a43ce3e66d52dbad6c6b2cfe6405ae0a07b43116680736", size = 3187824 },
+    { url = "https://files.pythonhosted.org/packages/33/b8/3f629158e8cd797c6d272579a8ca07f27b44b911dee562c2b9e56a5d7d4b/pyfixest-0.60.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1635437c4930d755b8432244d671d7490190be60ebca3257442296f3c6d06193", size = 3479304 },
+    { url = "https://files.pythonhosted.org/packages/81/70/5ee7cf0e40ef6c7733e1d330710e2333a5ab87435143cca08155ad11af33/pyfixest-0.60.0-cp314-cp314-win32.whl", hash = "sha256:91616c50fe04a8f0ad92b471f286a957fe9d1b209aa0d93555ec5d007bfeca1e", size = 2782979 },
+    { url = "https://files.pythonhosted.org/packages/a4/09/b32ed6e716607b2492019121062c3f4f3c72ead31ef6f22f0813e80fcfa2/pyfixest-0.60.0-cp314-cp314-win_amd64.whl", hash = "sha256:9dbf24d980f8436fb284d4dfe25e8433ffbfa83d564bad08132140bebb4ba634", size = 3109047 },
+    { url = "https://files.pythonhosted.org/packages/50/ec/0bc294031b64c6f1406dc7c58f6adb9f82411699ced2e3043c15706298ae/pyfixest-0.60.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:408c29df79b5a2443167b23562679de50ffb750554339739b6910f2f3964481f", size = 2903546 },
+    { url = "https://files.pythonhosted.org/packages/a6/a0/267be13be7b0e83aac7e699e25bc18407b8c282b78149d005afb05f40efa/pyfixest-0.60.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9f0544a32661f6c0a5b9396f039fed05d00d52d405223e2f131cb7b389f990a9", size = 2803574 },
+    { url = "https://files.pythonhosted.org/packages/10/03/93a8497890c101f0d9ddd0d75a7c480a8c6b971f4c8811b8ee36d4e7e87d/pyfixest-0.60.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:94ac0e373bc9ce7b2993cf0a08dcdda028aecea00277b3f443fa7ad57a284080", size = 2949316 },
+    { url = "https://files.pythonhosted.org/packages/8b/59/47b43be2326fe3d026423623aa6d2c895564b065a72fd0e71b96dffa9483/pyfixest-0.60.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dbafebc399bfd6d5dcbc4b87eb06df37317cb1895da65ef9675bbfe8b8f55f38", size = 2919432 },
+    { url = "https://files.pythonhosted.org/packages/27/93/67a4c70cf0e476d44d144364fa72d59b2af123f12db27651eafeffb417be/pyfixest-0.60.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bab39fcd20290a5762e9ed98a3db099d8978fb896763c3ab1157fbf9ad8701d0", size = 3080037 },
+    { url = "https://files.pythonhosted.org/packages/36/58/bdb92d1c3ecdc9b3d00de18e95e23cfdda653636f16e60a50942f270c5f6/pyfixest-0.60.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:845ff46053ef73d7d2bcd7233e663a9f24b1f6c8db88602711f0b622a5ffeb63", size = 3078697 },
+    { url = "https://files.pythonhosted.org/packages/16/38/2d6068fd9e56eab1ed602011f86acc02a8e6a2b1697b013457cf93b739db/pyfixest-0.60.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:4f07def1575af8ae7d9cdb96c72690c83b36524031034167fcb237c8a6526e53", size = 3186516 },
+    { url = "https://files.pythonhosted.org/packages/0b/73/7e608a5d2c72e4c9649ff52357956c954333b06aa74bfb02be7c88d8695f/pyfixest-0.60.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2d45e9b3872178bfd24322aabd4d9718b676272039ff5ad30a06c019155f7361", size = 3478508 },
+    { url = "https://files.pythonhosted.org/packages/eb/28/9fb3bc2159ae93e2bfe485533c87d8025674dda6a9eabab6a27056cf652f/pyfixest-0.60.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c3521f2c360c5efd8b91c7129cd42f9e1594e97be94745272dcffd21fb1933c", size = 2905732 },
+    { url = "https://files.pythonhosted.org/packages/d3/86/0eb8e25bebef16992accc280bf4b0aef1ec4bc683dc9e624e0b43f5cdbdd/pyfixest-0.60.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:32fb8891e241cad7ffc8dd4cb40639e748eec17390fda35bc905360a0eef47d5", size = 2805108 },
+    { url = "https://files.pythonhosted.org/packages/bb/0b/06eb97d560254ab39187a376aff1656cdad9590574e03ba0c33949a96bf8/pyfixest-0.60.0-pp311-pypy311_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2ca0e7ccc592d251fc2954635a5fcc9410db45795a7baef2d477697f9a600704", size = 2984878 },
+    { url = "https://files.pythonhosted.org/packages/3b/7d/7d49e73bc702216380d8d0cb85bc1e1bd9d4d72e5504bfe39c297c3e68c4/pyfixest-0.60.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:283c0227639dec9a884b7f46fb539f384f1370137137ef19ec6a36af67c4fa88", size = 2951882 },
+    { url = "https://files.pythonhosted.org/packages/ca/fc/163db34dfca1714c08855ea1167188b31927ca7c7bac43a57fbcd3c1fd29/pyfixest-0.60.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c0b279e0bde5a7071c61cdb6697861f50aadb6136405100bd9814001ec2aaa72", size = 2921057 },
+    { url = "https://files.pythonhosted.org/packages/76/b9/972ed0ceeccf65471ea896eacf3c9ec3a254575e67c4ec0c27b8c682af5e/pyfixest-0.60.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e3bf4f730451931e57605bbe712aec81658e912936617d7a7d52b4ac928e442", size = 3266947 },
+    { url = "https://files.pythonhosted.org/packages/26/58/c8c7f126e16aca9d62a7e9824b5431326861e3a02393b93b9c3332a38cb1/pyfixest-0.60.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:85445b919ec663385282e3fa2f2bbb6f0db46a7416e08ffa4f251cdb1ef3131d", size = 3082387 },
+    { url = "https://files.pythonhosted.org/packages/63/57/cd560a0664cc393f65ed0d90a62e98428006b102b3ec3c35ebe2609f5f09/pyfixest-0.60.0-pp311-pypy311_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:d0ac25851595dd7b5dfca7970a663f389fe04546cf15f87a92da79c4b3d6ba27", size = 3080122 },
+    { url = "https://files.pythonhosted.org/packages/90/8b/9210c7ab326afd2b30113c12a79842c1a09213bce99ecfcf9b12c69a5c05/pyfixest-0.60.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:143d516487a9ce54965c579122a48153f205c638c1ff5d933c151097b0d33665", size = 3186413 },
+    { url = "https://files.pythonhosted.org/packages/ac/41/3955ec519ef50d7f14580b96ae0b916e74ba056d3172680f41781204201f/pyfixest-0.60.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:8eebbaf9647c9a5bccdcc0806b51ba903292748b0604125c2a80ac5a427c1299", size = 3480039 },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1353,6 +1696,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892 },
+]
+
+[[package]]
+name = "python-docx"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/f7/eddfe33871520adab45aaa1a71f0402a2252050c14c7e3009446c8f4701c/python_docx-1.2.0.tar.gz", hash = "sha256:7bc9d7b7d8a69c9c02ca09216118c86552704edc23bac179283f2e38f86220ce", size = 5723256 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/00/1e03a4989fa5795da308cd774f05b704ace555a70f9bf9d3be057b680bcf/python_docx-1.2.0-py3-none-any.whl", hash = "sha256:3fd478f3250fbbbfd3b94fe1e985955737c145627498896a8a6bf81f4baf66c7", size = 252987 },
 ]
 
 [[package]]
@@ -1716,6 +2072,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814 },
+]
+
+[[package]]
 name = "threadpoolctl"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1818,6 +2183,65 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166 },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/db/de907251b4ff46ae804ad0409809504153b3f30984daf82a1d84a9875830/websockets-16.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:31a52addea25187bde0797a97d6fc3d2f92b6f72a9370792d65a6e84615ac8a8", size = 177340 },
+    { url = "https://files.pythonhosted.org/packages/f3/fa/abe89019d8d8815c8781e90d697dec52523fb8ebe308bf11664e8de1877e/websockets-16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:417b28978cdccab24f46400586d128366313e8a96312e4b9362a4af504f3bbad", size = 175022 },
+    { url = "https://files.pythonhosted.org/packages/58/5d/88ea17ed1ded2079358b40d31d48abe90a73c9e5819dbcde1606e991e2ad/websockets-16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:af80d74d4edfa3cb9ed973a0a5ba2b2a549371f8a741e0800cb07becdd20f23d", size = 175319 },
+    { url = "https://files.pythonhosted.org/packages/d2/ae/0ee92b33087a33632f37a635e11e1d99d429d3d323329675a6022312aac2/websockets-16.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:08d7af67b64d29823fed316505a89b86705f2b7981c07848fb5e3ea3020c1abe", size = 184631 },
+    { url = "https://files.pythonhosted.org/packages/c8/c5/27178df583b6c5b31b29f526ba2da5e2f864ecc79c99dae630a85d68c304/websockets-16.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7be95cfb0a4dae143eaed2bcba8ac23f4892d8971311f1b06f3c6b78952ee70b", size = 185870 },
+    { url = "https://files.pythonhosted.org/packages/87/05/536652aa84ddc1c018dbb7e2c4cbcd0db884580bf8e95aece7593fde526f/websockets-16.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d6297ce39ce5c2e6feb13c1a996a2ded3b6832155fcfc920265c76f24c7cceb5", size = 185361 },
+    { url = "https://files.pythonhosted.org/packages/6d/e2/d5332c90da12b1e01f06fb1b85c50cfc489783076547415bf9f0a659ec19/websockets-16.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1c1b30e4f497b0b354057f3467f56244c603a79c0d1dafce1d16c283c25f6e64", size = 184615 },
+    { url = "https://files.pythonhosted.org/packages/77/fb/d3f9576691cae9253b51555f841bc6600bf0a983a461c79500ace5a5b364/websockets-16.0-cp311-cp311-win32.whl", hash = "sha256:5f451484aeb5cafee1ccf789b1b66f535409d038c56966d6101740c1614b86c6", size = 178246 },
+    { url = "https://files.pythonhosted.org/packages/54/67/eaff76b3dbaf18dcddabc3b8c1dba50b483761cccff67793897945b37408/websockets-16.0-cp311-cp311-win_amd64.whl", hash = "sha256:8d7f0659570eefb578dacde98e24fb60af35350193e4f56e11190787bee77dac", size = 178684 },
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365 },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038 },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328 },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915 },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152 },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583 },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880 },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261 },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693 },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364 },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039 },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323 },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975 },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203 },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653 },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920 },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255 },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689 },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406 },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085 },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328 },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044 },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279 },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711 },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982 },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915 },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381 },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737 },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268 },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486 },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331 },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501 },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062 },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356 },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085 },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531 },
+    { url = "https://files.pythonhosted.org/packages/72/07/c98a68571dcf256e74f1f816b8cc5eae6eb2d3d5cfa44d37f801619d9166/websockets-16.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:349f83cd6c9a415428ee1005cadb5c2c56f4389bc06a9af16103c3bc3dcc8b7d", size = 174947 },
+    { url = "https://files.pythonhosted.org/packages/7e/52/93e166a81e0305b33fe416338be92ae863563fe7bce446b0f687b9df5aea/websockets-16.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:4a1aba3340a8dca8db6eb5a7986157f52eb9e436b74813764241981ca4888f03", size = 175260 },
+    { url = "https://files.pythonhosted.org/packages/56/0c/2dbf513bafd24889d33de2ff0368190a0e69f37bcfa19009ef819fe4d507/websockets-16.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f4a32d1bd841d4bcbffdcb3d2ce50c09c3909fbead375ab28d0181af89fd04da", size = 176071 },
+    { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968 },
+    { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735 },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598 },
 ]
 
 [[package]]


### PR DESCRIPTION
Introduce fixed effects regression capabilities using the pyfixest library. This update includes enhancements to the ExperimentAnalyzer for validating fixed effects, improved diagnostics, and comprehensive documentation with examples. Adjustments ensure proper handling of bootstrap methods and relative confidence intervals for fixed effects outcomes. Tests cover various scenarios to ensure robustness.