### PR TITLE
test: align collinear FE test with min_switcher_pct gate

### DIFF
--- a/tests/test_fixed_effects.py
+++ b/tests/test_fixed_effects.py
@@ -72,11 +72,11 @@ def test_relative_effect_is_control_mean_delta():
     assert np.isnan(out["cov_coef_intercept"])
 
 
-def test_collinear_treatment_returns_nan_with_diagnostics():
-    """Between-unit treatment is collinear with unit FE -> pyfixest drops it."""
+def test_collinear_treatment_returns_nan_with_diagnostics(capsys):
+    """Between-unit treatment has 0% switchers -> switcher gate skips the fit."""
     df = make_panel(seed=5, between_unit=True)
-    with pytest.warns(UserWarning):
-        out = est().fixed_effects_regression(data=df, outcome_variable="y", fixed_effects=["unit"], covariates=["cov"])
+    out = est().fixed_effects_regression(data=df, outcome_variable="y", fixed_effects=["unit"], covariates=["cov"])
+    assert "switchers" in capsys.readouterr().err
     assert np.isnan(out["absolute_effect"])
     assert out["n_switchers"] == 0
     assert out["pct_switchers"] == 0.0


### PR DESCRIPTION
## Problem

CI on `main` is failing in `test_collinear_treatment_returns_nan_with_diagnostics`:

```
Failed: DID NOT WARN. No warnings of type (<class 'UserWarning'>,) were emitted.
```

## Cause

The `between_unit=True` panel has **0% switchers**, so the new `min_switcher_pct` gate (#a01f352) skips the fixed-effects fit *before* pyfixest is ever reached. Previously pyfixest dropped the collinear treatment and emitted a real `UserWarning`; now the gate logs the skip to stderr and returns NaN diagnostics, so no `UserWarning` is raised.

The estimator code is working as designed — the test was stale.

## Fix

Assert against the new gate path instead: check the logged skip message on stderr (via `capsys`, since the `Estimators` logger has `propagate = False`) plus the NaN/zero-switcher diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)