### PR TITLE
feat: multi-guardrail MVN joint shrinkage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@
 
 * move portfolio shrinkage APIs into `experiment_utils.shrinkage` (winner's curse, EB / t-prior, cumulative impact, joint / NSS, Airbnb \(\hat T_A\), MAP); re-exported from the package top-level and from `experiment_utils.utils` for compatibility — prefer `from experiment_utils.shrinkage import ...`
 * add `aggregate_shrunk_cumulative` and `nss_adjusted_cumulative_impact` (joint primary|guardrail shrink, then Kessler aggregate on primary)
+* add `joint_metric_shrinkage_mvn` and `nss_adjusted_cumulative_impact_mvn` (primary + flexible K guardrails in one MVN; magnitude only — not the scale rule; default `rho_guardrails="factor"`)
+* add `resolve_mvn_prior_sd` and `prior=` on MVN APIs (`"map"` / `{"tau2"}` / `{"scale","df"}`) — still normal–normal; t scale is plugged in as τ
 
 ### Statistical notes
 
 * NSS-adjusted cumulative helps on average when |ρ| is high and the guardrail is precise; at moderate ρ a single portfolio can look worse than primary-only EB (sampling noise)
+* Multi-guardrail MVN pools companions under a joint prior (default factor Corr(γⱼ,γₖ)=ρⱼρₖ). Keep the multi-NSS hard gate in `shipped`; do not use MVN as the ship rule. `"independent"` NSS–NSS correlations can yield a non-PD Σ when several |ρ| are large.
 
 ## [1.2.0](https://github.com/sdaza/experiment-utils-pd/compare/v1.1.11...v1.2.0) (2026-07-22)
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Source code: https://github.com/sdaza/experiment-utils-pd
 - **Equivalence Testing (TOST)**: Two One-Sided Tests for equivalence, non-inferiority, non-superiority, and minimum-effect (superiority by margin) following Lakens (2017, 2018), with absolute, relative, and Cohen's d bounds, Lakens' four-cell conclusion matrix, and dedicated visualization
 - **Power Analysis**: Calculate statistical power and find optimal sample sizes, including TOST equivalence power
 - **Retrodesign Analysis**: Assess reliability of study designs (Type S/M errors)
-- **Winner's-Curse Correction**: De-bias effects selected by significance — conditional truncated-normal estimate with selection-adjusted CI (two-sided or one-sided), empirical-Bayes / Student-t / Half-Cauchy-MAP shrinkage, program-level `cumulative_impact` / NSS-adjusted cumulative, Airbnb `process_level_total_effect`, optional `joint_metric_shrinkage` with `estimate_guardrail_rho` (all in `experiment_utils.shrinkage`), plus analyzer wrappers (`winners_curse_summary`, `cumulative_impact_summary`)
+- **Winner's-Curse Correction**: De-bias effects selected by significance — conditional truncated-normal estimate with selection-adjusted CI (two-sided or one-sided), empirical-Bayes / Student-t / Half-Cauchy-MAP shrinkage, program-level `cumulative_impact` / NSS-adjusted cumulative, Airbnb `process_level_total_effect`, optional `joint_metric_shrinkage` / `joint_metric_shrinkage_mvn` with `estimate_guardrail_rho` (all in `experiment_utils.shrinkage`), plus analyzer wrappers (`winners_curse_summary`, `cumulative_impact_summary`)
 - **Random Assignment**: Generate balanced treatment assignments with stratification
 
 ## Table of Contents
@@ -1632,7 +1632,9 @@ from experiment_utils.shrinkage import (
     fit_t_prior_with_estimated_mean,
     cumulative_impact,
     joint_metric_shrinkage,
+    joint_metric_shrinkage_mvn,
     nss_adjusted_cumulative_impact,
+    nss_adjusted_cumulative_impact_mvn,
     estimate_guardrail_rho,
     fit_normal_prior_map,
     process_level_total_effect,
@@ -1692,6 +1694,24 @@ nss = nss_adjusted_cumulative_impact(
     prior_sd_guard=rho_hat["tau_guard"],
 )
 
+# Multi-guardrail Bayes MVN (K flexible: 3, 5, 10, …) — magnitude, not the scale rule.
+# Pass the real all-NSS hard gate in shipped_mask; MVN only updates primary magnitude.
+mvn = joint_metric_shrinkage_mvn(
+    primary_effects, primary_ses,
+    guardrail_effects=[nss1, nss2, nss3],  # or (n, K) array
+    guardrail_ses=[se1, se2, se3],
+    rho_primary=[0.7, 0.5, 0.4],
+    prior_sd_primary=0.015,
+    rho_guardrails="factor",  # Corr(γ_j, γ_k)=ρ_j ρ_k; or "independent" / (K,K) matrix
+)
+nss_mvn = nss_adjusted_cumulative_impact_mvn(
+    primary_effects, primary_ses,
+    [nss1, nss2, nss3], [se1, se2, se3],
+    shipped=shipped_mask,
+    rho_primary=[0.7, 0.5, 0.4],
+    prior_sd_primary=0.015,
+)
+
 # Via the analyzer
 ea.cumulative_impact_summary(shipped="shipped", prior="map")
 ```
@@ -1713,10 +1733,17 @@ correlation with `estimate_guardrail_rho` before `joint_metric_shrinkage` /
 the guardrail is precise; at moderate ρ a single portfolio can look worse than
 primary-only EB (sampling noise).
 
+**Multi-guardrail MVN:** use `joint_metric_shrinkage_mvn` /
+`nss_adjusted_cumulative_impact_mvn` for primary **magnitude** given several
+NSS companions. Keep the all-pass (or product) hard gate in `shipped` — MVN is
+**not** the scale rule. Default `rho_guardrails="factor"`; `"independent"` can
+make Σ non-PD when several |ρ| are large.
+
 Runnable examples:
 
 - [`examples/shrinkage_methods_tour.py`](examples/shrinkage_methods_tour.py) — short seeded tour of each method
 - [`examples/scaled_ship_method_assessment.py`](examples/scaled_ship_method_assessment.py) — MC: which shrinker wins under SCALED ship (sig + guardrail ≥ 0)
+- [`examples/joint_metric_shrinkage_mvn.py`](examples/joint_metric_shrinkage_mvn.py) — multi-guardrail MVN vs univ / bivariate (K=3, K=5)
 - [`examples/cumulative_impact.py`](examples/cumulative_impact.py) — shrink-then-sum vs naive winners
 - [`examples/cumulative_impact_extensions.py`](examples/cumulative_impact_extensions.py) — Airbnb / MAP / joint
 - [`examples/guardrail_correlation_prior.py`](examples/guardrail_correlation_prior.py) — when joint beats primary-only

--- a/examples/joint_metric_shrinkage_mvn.py
+++ b/examples/joint_metric_shrinkage_mvn.py
@@ -1,0 +1,317 @@
+# %% [markdown]
+# # Multi-guardrail MVN vs one guardrail
+#
+# Seeded Monte Carlo: does `joint_metric_shrinkage_mvn` (K companions) beat
+# bivariate `joint_metric_shrinkage` / `nss_adjusted_cumulative_impact` with
+# **just one** companion?
+#
+# **Magnitude only — not the scale rule.** `shipped` encodes a hard multi-guardrail
+# gate (no companion significantly negative at one-sided p<0.1); see section 2.
+#
+# Run: `uv run python examples/joint_metric_shrinkage_mvn.py`
+
+# %%
+from __future__ import annotations
+
+import numpy as np
+from scipy.stats import norm
+
+from experiment_utils.shrinkage import (
+    cumulative_impact,
+    empirical_bayes_shrinkage,
+    fit_t_prior,
+    joint_metric_shrinkage,
+    joint_metric_shrinkage_mvn,
+    nss_adjusted_cumulative_impact,
+    nss_adjusted_cumulative_impact_mvn,
+)
+
+rng = np.random.default_rng(2026)
+
+
+def section(title: str) -> None:
+    print("\n" + "=" * 72)
+    print(title)
+    print("=" * 72)
+
+
+def sim_portfolio(n: int, tau: float, rhos: tuple[float, ...], se_p: float, se_g: float):
+    """One-factor DGP: Corr(γ_j, γ_k) = ρ_j ρ_k (matches rho_guardrails='factor')."""
+    k = len(rhos)
+    delta = tau * rng.standard_normal(n)
+    g_true = np.empty((n, k))
+    for j, rho in enumerate(rhos):
+        g_true[:, j] = rho * delta + tau * np.sqrt(1 - rho**2) * rng.standard_normal(n)
+    x = delta + rng.normal(0, se_p, n)
+    g = g_true + rng.normal(0, se_g, size=(n, k))
+    return delta, x, g
+
+
+def pass_fail(ok: bool) -> str:
+    return "PASS" if ok else "FAIL"
+
+
+# %% [markdown]
+# ## 1. Per-experiment MSE: each single NSS vs all three at once
+
+# %%
+section("1) Primary MSE: one guardrail vs MVN K=3")
+
+n, tau = 120, 0.015
+rhos = (0.8, 0.7, 0.6)
+names = ("NSS1 (ρ=0.8)", "NSS2 (ρ=0.7)", "NSS3 (ρ=0.6)")
+se_p, se_g = 0.03, 0.01
+n_sim = 300
+
+mse_univ = 0.0
+mse_one = np.zeros(len(rhos))
+mse_mvn = 0.0
+
+for _ in range(n_sim):
+    delta, x, g = sim_portfolio(n, tau, rhos, se_p, se_g)
+    se_pa = np.full(n, se_p)
+    se_ga = np.full_like(g, se_g)
+
+    univ = empirical_bayes_shrinkage(x, se_pa, prior_mean=0.0, tau2=tau**2)
+    mse_univ += float(np.mean((univ["shrunk"] - delta) ** 2))
+
+    for j, rho in enumerate(rhos):
+        bi = joint_metric_shrinkage(
+            x,
+            se_pa,
+            g[:, j],
+            se_ga[:, j],
+            rho=rho,
+            prior_sd_primary=tau,
+            prior_sd_guard=tau,
+        )
+        mse_one[j] += float(np.mean((bi["primary_shrunk"] - delta) ** 2))
+
+    mvn = joint_metric_shrinkage_mvn(
+        x,
+        se_pa,
+        g,
+        se_ga,
+        rho_primary=list(rhos),
+        prior_sd_primary=tau,
+        prior_sd_guard=tau,
+    )
+    mse_mvn += float(np.mean((mvn["primary_shrunk"] - delta) ** 2))
+
+mse_univ /= n_sim
+mse_one /= n_sim
+mse_mvn /= n_sim
+best_one = float(np.min(mse_one))
+best_idx = int(np.argmin(mse_one))
+
+print(f"  n_sim={n_sim}, n_exp={n}, se_p={se_p}, se_g={se_g}")
+print(f"  primary-only EB          MSE = {mse_univ:.6f}")
+for j, name in enumerate(names):
+    print(f"  one guardrail {name:16s} MSE = {mse_one[j]:.6f}")
+print(f"  MVN all K=3              MSE = {mse_mvn:.6f}")
+print(f"  best single companion    = {names[best_idx]}")
+print(f"  MVN vs best one          : {100 * (1 - mse_mvn / best_one):+.1f}% MSE [{pass_fail(mse_mvn < best_one)}]")
+print(f"  MVN vs primary-only      : [{pass_fail(mse_mvn < mse_univ)}]")
+
+# %% [markdown]
+# ## 2. Cumulative under hard guardrail gate vs MVN K=5
+#
+# Same `shipped` for everyone: primary significant (two-sided 0.05) and no
+# companion significantly negative at one-sided α=0.1
+# (``g_k / SE_k >= -z_{0.90}`` for all k; up-metrics). MVN is not the scale rule.
+
+# %%
+section("2) Cumulative MAE: best one guardrail vs MVN K=5 (same shipped)")
+
+rhos5 = (0.75, 0.70, 0.65, 0.60, 0.55)
+names5 = [f"guard{j + 1} (ρ={r})" for j, r in enumerate(rhos5)]
+z_primary = norm.ppf(0.975)  # primary win, two-sided 0.05
+z_guard_neg = norm.ppf(0.90)  # one-sided α=0.1: significantly negative
+n_exp, n_port = 100, 400
+
+true_s: list[float] = []
+naive_s: list[float] = []
+univ_s: list[float] = []
+one_s = [[] for _ in rhos5]  # type: list[list[float]]
+mvn_s: list[float] = []
+
+for _ in range(n_port):
+    delta, x, g = sim_portfolio(n_exp, tau, rhos5, se_p, se_g)
+    # Hard gate: block if any guardrail significantly negative @ one-sided 0.1
+    guard_ok = np.all(g >= -z_guard_neg * se_g, axis=1)
+    ship = (x > z_primary * se_p) & guard_ok
+    if int(ship.sum()) < 2:
+        continue
+    true_s.append(float(delta[ship].sum()))
+    naive_s.append(float(x[ship].sum()))
+    univ_s.append(cumulative_impact(x, np.full(n_exp, se_p), shipped=ship, tau2=tau**2, prior_mean=0.0)["cumulative"])
+    for j, rho in enumerate(rhos5):
+        one_s[j].append(
+            nss_adjusted_cumulative_impact(
+                x,
+                np.full(n_exp, se_p),
+                g[:, j],
+                np.full(n_exp, se_g),
+                shipped=ship,
+                rho=rho,
+                prior_sd_primary=tau,
+                prior_sd_guard=tau,
+            )["cumulative"]
+        )
+    mvn_s.append(
+        nss_adjusted_cumulative_impact_mvn(
+            x,
+            np.full(n_exp, se_p),
+            g,
+            np.full_like(g, se_g),
+            shipped=ship,
+            rho_primary=list(rhos5),
+            prior_sd_primary=tau,
+            prior_sd_guard=tau,
+        )["cumulative"]
+    )
+
+truth = np.asarray(true_s)
+naive_a = np.asarray(naive_s)
+univ_a = np.asarray(univ_s)
+mvn_a = np.asarray(mvn_s)
+one_mae = [float(np.mean(np.abs(np.asarray(one_s[j]) - truth))) for j in range(len(rhos5))]
+best_one_j = int(np.argmin(one_mae))
+
+naive_mae = float(np.mean(np.abs(naive_a - truth)))
+univ_mae = float(np.mean(np.abs(univ_a - truth)))
+mvn_mae = float(np.mean(np.abs(mvn_a - truth)))
+naive_bias = float(np.mean(naive_a - truth))
+univ_bias = float(np.mean(univ_a - truth))
+mvn_bias = float(np.mean(mvn_a - truth))
+best_one_mae = one_mae[best_one_j]
+best_one_bias = float(np.mean(np.asarray(one_s[best_one_j]) - truth))
+
+print(f"  n portfolios used = {len(true_s)} (of {n_port} draws)")
+print(f"  {'method':28s}  {'MAE':>8s}  {'bias':>9s}")
+print(f"  {'naive shipped sum':28s}  {naive_mae:8.4f}  {naive_bias:+9.4f}")
+print(f"  {'primary-only EB':28s}  {univ_mae:8.4f}  {univ_bias:+9.4f}")
+for j, name in enumerate(names5):
+    bias_j = float(np.mean(np.asarray(one_s[j]) - truth))
+    mark = " ← best one" if j == best_one_j else ""
+    print(f"  {'one: ' + name:28s}  {one_mae[j]:8.4f}  {bias_j:+9.4f}{mark}")
+print(f"  {'MVN all K=5':28s}  {mvn_mae:8.4f}  {mvn_bias:+9.4f}")
+print()
+print(f"  MVN MAE < best one-guardrail MAE? {mvn_mae:.4f} < {best_one_mae:.4f}  [{pass_fail(mvn_mae < best_one_mae)}]")
+print(
+    f"  MVN |bias| < naive |bias|?          "
+    f"{abs(mvn_bias):.4f} < {abs(naive_bias):.4f}  [{pass_fail(abs(mvn_bias) < abs(naive_bias))}]"
+)
+print(
+    "\n  Same shipped mask for all rows (primary sig + no guardrail significantly\n"
+    "  negative @ one-sided 0.1). MVN only changes primary magnitude."
+)
+
+# %% [markdown]
+# ## 3. prior="map" and Student-t scale plug-in (still normal MVN)
+#
+# Learn τ from the primary archive (Half-Cauchy MAP or t scale), then run the
+# same multi-guardrail MVN. Not a multivariate-t — just easier prior plug-in.
+
+# %%
+section("3) MVN with prior='map' / t-scale vs known-τ and one guardrail")
+
+n3, n_sim3 = 120, 250
+rhos3 = (0.8, 0.7, 0.6)
+mse_known = mse_map = mse_t = mse_one_best = mse_univ3 = 0.0
+map_sds: list[float] = []
+t_sds: list[float] = []
+
+for _ in range(n_sim3):
+    delta, x, g = sim_portfolio(n3, tau, rhos3, se_p, se_g)
+    se_pa = np.full(n3, se_p)
+    se_ga = np.full_like(g, se_g)
+
+    univ = empirical_bayes_shrinkage(x, se_pa, prior_mean=0.0, tau2=tau**2)
+    mse_univ3 += float(np.mean((univ["shrunk"] - delta) ** 2))
+
+    one_mses = [
+        float(
+            np.mean(
+                (
+                    joint_metric_shrinkage(
+                        x,
+                        se_pa,
+                        g[:, j],
+                        se_ga[:, j],
+                        rho=rhos3[j],
+                        prior_sd_primary=tau,
+                        prior_sd_guard=tau,
+                    )["primary_shrunk"]
+                    - delta
+                )
+                ** 2
+            )
+        )
+        for j in range(len(rhos3))
+    ]
+    mse_one_best += min(one_mses)
+
+    known = joint_metric_shrinkage_mvn(
+        x,
+        se_pa,
+        g,
+        se_ga,
+        rho_primary=list(rhos3),
+        prior_sd_primary=tau,
+        prior_sd_guard=tau,
+    )
+    mse_known += float(np.mean((known["primary_shrunk"] - delta) ** 2))
+
+    mvn_map = joint_metric_shrinkage_mvn(
+        x,
+        se_pa,
+        g,
+        se_ga,
+        rho_primary=list(rhos3),
+        prior="map",
+    )
+    mse_map += float(np.mean((mvn_map["primary_shrunk"] - delta) ** 2))
+    map_sds.append(float(mvn_map["prior_sd_primary"]))
+
+    t_fit = fit_t_prior(x, se_pa, df=4.0, prior_mean=0.0)
+    mvn_t = joint_metric_shrinkage_mvn(
+        x,
+        se_pa,
+        g,
+        se_ga,
+        rho_primary=list(rhos3),
+        prior={"scale": t_fit["scale"], "df": t_fit["df"], "prior_mean": 0.0},
+    )
+    mse_t += float(np.mean((mvn_t["primary_shrunk"] - delta) ** 2))
+    t_sds.append(float(mvn_t["prior_sd_primary"]))
+
+mse_known /= n_sim3
+mse_map /= n_sim3
+mse_t /= n_sim3
+mse_one_best /= n_sim3
+mse_univ3 /= n_sim3
+
+print(f"  true τ = {tau:.4f}")
+print(f"  mean MAP prior_sd  = {np.mean(map_sds):.4f}")
+print(f"  mean t-scale SD    = {np.mean(t_sds):.4f}  (plugged into normal MVN)")
+print(f"  {'method':32s}  MSE")
+print(f"  {'primary-only EB (known τ)':32s}  {mse_univ3:.6f}")
+print(f"  {'best one guardrail (known τ)':32s}  {mse_one_best:.6f}")
+print(f"  {'MVN K=3 known τ':32s}  {mse_known:.6f}")
+print(f"  {'MVN K=3 prior=map':32s}  {mse_map:.6f}")
+print(f"  {'MVN K=3 prior=t-scale':32s}  {mse_t:.6f}")
+print()
+print(f"  MAP MVN beats best one-guardrail?  [{pass_fail(mse_map < mse_one_best)}]")
+print(f"  t-scale MVN beats best one-guardrail? [{pass_fail(mse_t < mse_one_best)}]")
+print(f"  MAP MVN beats primary-only?        [{pass_fail(mse_map < mse_univ3)}]")
+print(f"  t-scale MVN beats primary-only?    [{pass_fail(mse_t < mse_univ3)}]")
+print(
+    f"  MAP / known-τ MSE ratio = {mse_map / mse_known:.2f}x; "
+    f"t / known-τ = {mse_t / mse_known:.2f}x "
+    f"(oracle τ is best; learned priors a bit noisier)"
+)
+print(
+    "\n  Note: joint remains normal–normal; MAP/t only set prior_sd_primary\n"
+    "  (and mean for MAP). Not a multivariate-t posterior."
+)

--- a/experiment_utils/__init__.py
+++ b/experiment_utils/__init__.py
@@ -10,8 +10,11 @@ from .shrinkage import (
     fit_t_prior,
     fit_t_prior_with_estimated_mean,
     joint_metric_shrinkage,
+    joint_metric_shrinkage_mvn,
     nss_adjusted_cumulative_impact,
+    nss_adjusted_cumulative_impact_mvn,
     process_level_total_effect,
+    resolve_mvn_prior_sd,
     t_prior_shrinkage,
     winners_curse_estimate,
 )
@@ -46,7 +49,10 @@ __all__ = [
     "cumulative_impact",
     "aggregate_shrunk_cumulative",
     "joint_metric_shrinkage",
+    "joint_metric_shrinkage_mvn",
     "nss_adjusted_cumulative_impact",
+    "nss_adjusted_cumulative_impact_mvn",
     "process_level_total_effect",
     "estimate_guardrail_rho",
+    "resolve_mvn_prior_sd",
 ]

--- a/experiment_utils/shrinkage.py
+++ b/experiment_utils/shrinkage.py
@@ -1012,6 +1012,456 @@ def nss_adjusted_cumulative_impact(
     }
 
 
+def resolve_mvn_prior_sd(
+    effects,
+    standard_errors,
+    *,
+    prior: str | dict,
+    prior_mean: float = 0.0,
+) -> dict:
+    """
+    Resolve ``cumulative_impact``-style priors into a normal prior SD for MVN.
+
+    The multi-guardrail joint is always normal–normal. This helper only learns
+    ``(prior_mean, prior_sd)`` from the primary archive so you can plug MAP or
+    a Student-t *scale* into :func:`joint_metric_shrinkage_mvn`.
+
+    - ``prior="map"`` → :func:`fit_normal_prior_map` → ``prior_sd = sqrt(tau2)``
+    - ``prior={"tau2": ...}`` → ``prior_sd = sqrt(tau2)``
+    - ``prior={"scale", "df"}`` → ``prior_sd = scale`` (t scale as τ for the
+      normal MVN — **not** a multivariate-t posterior)
+
+    Optional ``prior_mean`` in a dict overrides the ``prior_mean`` kwarg.
+    """
+    y, s = _validate_effects_ses(effects, standard_errors)
+    if y.size < 1:
+        raise ValueError("effects must contain at least one estimate")
+
+    if prior == "map":
+        fitted = fit_normal_prior_map(y, s)
+        return {
+            "prior_sd": float(np.sqrt(fitted["tau2"])),
+            "prior_mean": float(fitted["prior_mean"]),
+            "prior_family": "normal",
+            "prior_source": "half_cauchy_map",
+            "tau2": float(fitted["tau2"]),
+        }
+
+    if not isinstance(prior, dict):
+        raise ValueError("prior must be 'map' or a dict with 'tau2' or 'scale'+'df'")
+
+    loc = float(prior.get("prior_mean", prior_mean))
+    if "scale" in prior and "df" in prior:
+        scale = float(prior["scale"])
+        if not (np.isfinite(scale) and scale > 0):
+            raise ValueError("prior['scale'] must be positive and finite")
+        return {
+            "prior_sd": scale,
+            "prior_mean": loc,
+            "prior_family": "student_t_scale_as_normal_sd",
+            "prior_source": "t_scale_plug_in",
+            "scale": scale,
+            "df": float(prior["df"]),
+            "tau2": float(scale**2),
+        }
+    if "tau2" in prior:
+        tau2 = float(prior["tau2"])
+        if not (np.isfinite(tau2) and tau2 > 0):
+            raise ValueError("prior['tau2'] must be positive and finite")
+        return {
+            "prior_sd": float(np.sqrt(tau2)),
+            "prior_mean": loc,
+            "prior_family": "normal",
+            "prior_source": "tau2",
+            "tau2": tau2,
+        }
+    raise ValueError("prior must contain 'tau2' or both 'scale' and 'df'")
+
+
+def _coerce_guardrail_matrix(guardrail_effects, guardrail_ses, n: int) -> tuple[np.ndarray, np.ndarray]:
+    """Accept list of K length-n arrays or (n, K) arrays → (n, K) float matrices."""
+    if isinstance(guardrail_effects, list | tuple):
+        cols = [np.asarray(c, dtype=float).reshape(-1) for c in guardrail_effects]
+        if not cols:
+            raise ValueError("guardrail_effects must contain at least one guardrail")
+        g = np.column_stack(cols)
+    else:
+        g = np.asarray(guardrail_effects, dtype=float)
+        if g.ndim == 1:
+            g = g.reshape(-1, 1)
+        if g.ndim != 2:
+            raise ValueError("guardrail_effects must be a list of arrays or a 2-D array")
+    if isinstance(guardrail_ses, list | tuple):
+        cols = [np.asarray(c, dtype=float).reshape(-1) for c in guardrail_ses]
+        if len(cols) != g.shape[1]:
+            raise ValueError("guardrail_ses must have the same number of columns as guardrail_effects")
+        sg = np.column_stack(cols)
+    else:
+        sg = np.asarray(guardrail_ses, dtype=float)
+        if sg.ndim == 1:
+            sg = sg.reshape(-1, 1)
+        if sg.ndim != 2:
+            raise ValueError("guardrail_ses must be a list of arrays or a 2-D array")
+    if g.shape[0] != n or sg.shape != g.shape:
+        raise ValueError("guardrail arrays must be aligned with primary (n experiments × K guardrails)")
+    if not np.all(np.isfinite(g)) or not np.all(np.isfinite(sg)):
+        raise ValueError("guardrail effects and SEs must be finite")
+    if np.any(sg <= 0):
+        raise ValueError("guardrail standard errors must be positive")
+    return g, sg
+
+
+def _build_prior_sigma(
+    *,
+    k: int,
+    rho_primary,
+    prior_sd_primary: float,
+    prior_sd_guard,
+    rho_guardrails,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Build (K+1)×(K+1) prior covariance; return (sigma, rho_primary_vec)."""
+    if np.isscalar(rho_primary):
+        rho_vec = np.full(k, float(rho_primary))
+    else:
+        rho_vec = np.asarray(rho_primary, dtype=float).reshape(-1)
+        if rho_vec.size != k:
+            raise ValueError(f"rho_primary must be a scalar or length-{k} sequence")
+    if not np.all(np.isfinite(rho_vec)) or np.any(np.abs(rho_vec) >= 1.0):
+        raise ValueError("rho_primary values must be finite and strictly inside (-1, 1)")
+
+    if prior_sd_guard is None:
+        tau_g = np.full(k, float(prior_sd_primary))
+    elif np.isscalar(prior_sd_guard):
+        tau_g = np.full(k, float(prior_sd_guard))
+    else:
+        tau_g = np.asarray(prior_sd_guard, dtype=float).reshape(-1)
+        if tau_g.size != k:
+            raise ValueError(f"prior_sd_guard must be a scalar or length-{k} sequence")
+    if not (np.isfinite(prior_sd_primary) and prior_sd_primary > 0):
+        raise ValueError("prior_sd_primary must be positive and finite")
+    if not np.all(np.isfinite(tau_g)) or np.any(tau_g <= 0):
+        raise ValueError("prior_sd_guard must be positive and finite")
+
+    sds = np.concatenate([[float(prior_sd_primary)], tau_g])
+    corr = np.eye(k + 1, dtype=float)
+    corr[0, 1:] = rho_vec
+    corr[1:, 0] = rho_vec
+    if isinstance(rho_guardrails, str):
+        if rho_guardrails == "independent":
+            pass  # guards uncorrelated with each other (may be non-PD if sum ρ² large)
+        elif rho_guardrails == "factor":
+            # One-factor: Corr(γ_j, γ_k) = ρ_j ρ_k (always PD when |ρ_k| < 1)
+            outer = np.outer(rho_vec, rho_vec)
+            np.fill_diagonal(outer, 1.0)
+            corr[1:, 1:] = outer
+        else:
+            raise ValueError("rho_guardrails must be 'factor', 'independent', or a (K, K) correlation matrix")
+    else:
+        r = np.asarray(rho_guardrails, dtype=float)
+        if r.shape != (k, k):
+            raise ValueError(f"rho_guardrails matrix must have shape ({k}, {k})")
+        if not np.allclose(r, r.T, atol=1e-10):
+            raise ValueError("rho_guardrails correlation matrix must be symmetric")
+        if not np.allclose(np.diag(r), 1.0, atol=1e-8):
+            raise ValueError("rho_guardrails correlation matrix must have unit diagonal")
+        if not np.all(np.isfinite(r)) or np.any(np.abs(r) > 1.0 + 1e-8):
+            raise ValueError("rho_guardrails entries must be finite correlations in [-1, 1]")
+        corr[1:, 1:] = r
+
+    sigma = np.outer(sds, sds) * corr
+    # PD check (allow tiny numerical slack)
+    eig = np.linalg.eigvalsh(sigma)
+    if eig.min() <= 1e-12:
+        raise ValueError(
+            "prior covariance Sigma is not positive definite; "
+            "check rho_primary and rho_guardrails (try rho_guardrails='factor')"
+        )
+    return sigma, rho_vec
+
+
+def joint_metric_shrinkage_mvn(
+    primary_effects,
+    primary_ses,
+    guardrail_effects,
+    guardrail_ses,
+    *,
+    rho_primary,
+    prior_sd_primary: float | None = None,
+    prior_sd_guard=None,
+    prior_mean_primary: float = 0.0,
+    prior_mean_guard=0.0,
+    prior: str | dict | None = None,
+    rho_guardrails="factor",
+    ci: float = 0.95,
+    guardrail_names=None,
+) -> dict:
+    """
+    Multivariate normal–normal shrinkage: primary + K guardrails.
+
+    Bayes posterior for true effects ``(delta, gamma_1, ..., gamma_K)`` under a
+    joint normal prior and independent sampling noise. Flexible ``K`` (1, 3, 5,
+    10, …). When ``K=1`` this matches :func:`joint_metric_shrinkage`.
+
+    Default ``rho_guardrails="factor"`` sets
+    ``Corr(gamma_j, gamma_k) = rho_j * rho_k`` (one shared primary factor).
+    That stays positive-definite whenever each ``|rho_k| < 1``. Use
+    ``"independent"`` only when NSS–NSS correlations are truly ~0 *and* the
+    resulting Sigma is PD (high primary correlations often make independent
+    guards impossible). Pass a ``(K, K)`` matrix when the full structure is known.
+
+    Prior SDs: pass ``prior_sd_primary`` directly, or ``prior=`` as in
+    :func:`cumulative_impact` (``"map"``, ``{"tau2"}``, or ``{"scale","df"}``).
+    Student-t ``scale`` is plugged in as a normal SD — this is **not** a
+    multivariate-t joint (see :func:`resolve_mvn_prior_sd`).
+
+    **Magnitude only — not the scale/ship rule.** Keep the multi-guardrail hard
+    gate in the caller's ``shipped`` mask; use this for primary magnitude given
+    companions.
+
+    Parameters
+    ----------
+    primary_effects, primary_ses : array-like
+        Length-``n`` primary lifts and SEs.
+    guardrail_effects, guardrail_ses : list of arrays or (n, K) array
+        Aligned companion metrics.
+    rho_primary : float or length-K sequence
+        Corr(true primary, true guardrail_k).
+    prior_sd_primary, prior_sd_guard : float or length-K
+        Prior SDs; guard defaults to ``prior_sd_primary``. Required unless
+        ``prior=`` is set.
+    prior : ``"map"`` or dict, optional
+        Archive prior for the primary (resolved via :func:`resolve_mvn_prior_sd`).
+    rho_guardrails : ``"factor"``, ``"independent"``, or (K, K) array
+        Correlations among true guardrail effects.
+    """
+    x, sx = _validate_effects_ses(primary_effects, primary_ses)
+    if x.size < 1:
+        raise ValueError("effects must contain at least one estimate")
+    if not 0 < ci < 1:
+        raise ValueError("ci must be strictly between 0 and 1")
+
+    prior_meta: dict = {}
+    if prior is not None:
+        if prior_sd_primary is not None:
+            raise ValueError("pass only one of prior= and prior_sd_primary")
+        resolved = resolve_mvn_prior_sd(x, sx, prior=prior, prior_mean=prior_mean_primary)
+        prior_sd_primary = resolved["prior_sd"]
+        prior_mean_primary = float(resolved["prior_mean"])
+        prior_meta = {
+            "prior_family": resolved["prior_family"],
+            "prior_source": resolved["prior_source"],
+            **{k: resolved[k] for k in ("tau2", "scale", "df") if k in resolved},
+        }
+    if prior_sd_primary is None:
+        raise ValueError("pass prior_sd_primary= or prior= ('map' / {'tau2'} / {'scale','df'})")
+
+    g, sg = _coerce_guardrail_matrix(guardrail_effects, guardrail_ses, x.size)
+    k = g.shape[1]
+    sigma, rho_vec = _build_prior_sigma(
+        k=k,
+        rho_primary=rho_primary,
+        prior_sd_primary=float(prior_sd_primary),
+        prior_sd_guard=prior_sd_guard,
+        rho_guardrails=rho_guardrails,
+    )
+
+    if np.isscalar(prior_mean_guard):
+        mu_g = np.full(k, float(prior_mean_guard))
+    else:
+        mu_g = np.asarray(prior_mean_guard, dtype=float).reshape(-1)
+        if mu_g.size != k:
+            raise ValueError(f"prior_mean_guard must be a scalar or length-{k} sequence")
+    mu = np.concatenate([[float(prior_mean_primary)], mu_g])
+
+    if guardrail_names is not None:
+        names = list(guardrail_names)
+        if len(names) != k:
+            raise ValueError(f"guardrail_names must have length {k}")
+    else:
+        names = None
+
+    z = float(norm.ppf(1.0 - (1.0 - ci) / 2.0))
+    sigma_inv = np.linalg.inv(sigma)
+    primary_shrunk = np.empty(x.size)
+    primary_sd = np.empty(x.size)
+    guard_shrunk = np.empty_like(g)
+    guard_sd = np.empty_like(g)
+
+    for i in range(x.size):
+        y = np.concatenate([[x[i]], g[i]])
+        v = np.diag(np.concatenate([[sx[i] ** 2], sg[i] ** 2]))
+        v_inv = np.diag(1.0 / np.diag(v))
+        post_cov = np.linalg.inv(sigma_inv + v_inv)
+        a = sigma @ np.linalg.inv(sigma + v)
+        post_mean = mu + a @ (y - mu)
+        primary_shrunk[i] = post_mean[0]
+        primary_sd[i] = float(np.sqrt(max(post_cov[0, 0], 0.0)))
+        guard_shrunk[i] = post_mean[1:]
+        guard_sd[i] = np.sqrt(np.maximum(np.diag(post_cov)[1:], 0.0))
+
+    out = {
+        "method": "joint_metric_shrinkage_mvn",
+        "primary_shrunk": primary_shrunk,
+        "primary_posterior_sd": primary_sd,
+        "primary_ci_lower": primary_shrunk - z * primary_sd,
+        "primary_ci_upper": primary_shrunk + z * primary_sd,
+        "guard_shrunk": guard_shrunk,
+        "guard_posterior_sd": guard_sd,
+        "rho_primary": rho_vec,
+        "prior_sd_primary": float(prior_sd_primary),
+        "prior_sd_guard": np.sqrt(np.diag(sigma)[1:]).copy(),
+        "prior_mean_primary": float(prior_mean_primary),
+        "prior_mean_guard": mu_g.copy(),
+        "rho_guardrails": rho_guardrails if isinstance(rho_guardrails, str) else np.asarray(rho_guardrails),
+        "sigma": sigma,
+        "n_guardrails": int(k),
+        "guardrail_names": names,
+        **prior_meta,
+    }
+    return out
+
+
+def nss_adjusted_cumulative_impact_mvn(
+    primary_effects,
+    primary_ses,
+    guardrail_effects,
+    guardrail_ses,
+    *,
+    shipped=None,
+    coverage=None,
+    rho_primary=None,
+    prior_sd_primary: float | None = None,
+    prior_sd_guard=None,
+    prior_mean_primary: float = 0.0,
+    prior_mean_guard=0.0,
+    prior: str | dict | None = None,
+    rho_guardrails="factor",
+    aggregation: str = "sum",
+    ci: float = 0.95,
+    min_shipped: int = 1,
+    guardrail_names=None,
+) -> dict:
+    """
+    Multi-guardrail MVN joint shrink, then Kessler aggregate on primary.
+
+    Composes :func:`joint_metric_shrinkage_mvn` with
+    :func:`aggregate_shrunk_cumulative`. When ``rho_primary`` / prior SDs are
+    omitted they are estimated via :func:`estimate_guardrail_rho` on each
+    primary×NSS pair (``rho_guardrails`` still defaults to ``"factor"``).
+
+    Optional ``prior=`` (``"map"``, ``{"tau2"}``, ``{"scale","df"}``) sets the
+    primary normal SD via :func:`resolve_mvn_prior_sd` (still a normal MVN).
+
+    **Magnitude only — not the scale/ship rule.** Pass the real multi-guardrail
+    hard gate in ``shipped``.
+    """
+    y, sy = _validate_effects_ses(primary_effects, primary_ses)
+    g, sg = _coerce_guardrail_matrix(guardrail_effects, guardrail_ses, y.size)
+    k = g.shape[1]
+
+    prior_meta: dict = {}
+    if prior is not None:
+        if prior_sd_primary is not None:
+            raise ValueError("pass only one of prior= and prior_sd_primary")
+        resolved = resolve_mvn_prior_sd(y, sy, prior=prior, prior_mean=prior_mean_primary)
+        prior_sd_primary = resolved["prior_sd"]
+        prior_mean_primary = float(resolved["prior_mean"])
+        prior_meta = {
+            "prior_family": resolved["prior_family"],
+            "prior_source": resolved["prior_source"],
+            **{k_: resolved[k_] for k_ in ("tau2", "scale", "df") if k_ in resolved},
+        }
+
+    need_mom = rho_primary is None or prior_sd_primary is None or prior_sd_guard is None
+    if need_mom:
+        if y.size < 5:
+            raise ValueError(
+                "estimating rho / prior SDs requires at least 5 paired experiments; "
+                "pass rho_primary, prior_sd_primary (or prior=), and prior_sd_guard explicitly"
+            )
+        rhos = []
+        tau_gs = []
+        tau_ps = []
+        for j in range(k):
+            mom = estimate_guardrail_rho(
+                y,
+                sy,
+                g[:, j],
+                sg[:, j],
+                prior_mean_primary=prior_mean_primary,
+                prior_mean_guard=(
+                    float(prior_mean_guard)
+                    if np.isscalar(prior_mean_guard)
+                    else float(np.asarray(prior_mean_guard).reshape(-1)[j])
+                ),
+            )
+            rhos.append(mom["rho"])
+            tau_gs.append(mom["tau_guard"])
+            tau_ps.append(mom["tau_primary"])
+        if rho_primary is None:
+            rho_hat = np.asarray(rhos, dtype=float)
+        elif np.isscalar(rho_primary):
+            rho_hat = np.full(k, float(rho_primary))
+        else:
+            rho_hat = np.asarray(rho_primary, dtype=float).reshape(-1)
+        if prior_sd_primary is not None:
+            sd_p = float(prior_sd_primary)
+        else:
+            positive = [t for t in tau_ps if t > 0]
+            if not positive:
+                raise ValueError("estimated prior_sd_primary is 0 for all pairs; pass prior_sd_primary or prior=")
+            sd_p = float(np.mean(positive))
+        if prior_sd_guard is None:
+            sd_g = np.asarray([t if t > 0 else sd_p for t in tau_gs], dtype=float)
+        elif np.isscalar(prior_sd_guard):
+            sd_g = float(prior_sd_guard)
+        else:
+            sd_g = prior_sd_guard
+        rho_info = {"rho_primary": rho_hat, "tau_guards": tau_gs, "source": "mom"}
+    else:
+        rho_hat = rho_primary
+        sd_p = float(prior_sd_primary)
+        sd_g = prior_sd_guard
+        rho_info = {"rho_primary": rho_hat, "source": "caller"}
+
+    joint = joint_metric_shrinkage_mvn(
+        y,
+        sy,
+        g,
+        sg,
+        rho_primary=rho_hat,
+        prior_sd_primary=sd_p,
+        prior_sd_guard=sd_g,
+        prior_mean_primary=prior_mean_primary,
+        prior_mean_guard=prior_mean_guard,
+        rho_guardrails=rho_guardrails,
+        ci=ci,
+        guardrail_names=guardrail_names,
+    )
+    agg = aggregate_shrunk_cumulative(
+        joint["primary_shrunk"],
+        joint["primary_posterior_sd"],
+        shipped=shipped,
+        coverage=coverage,
+        observed=y,
+        aggregation=aggregation,
+        ci=ci,
+        min_shipped=min_shipped,
+    )
+    return {
+        "method": "joint_metric_shrinkage_mvn → Kessler aggregate (magnitude; not scale rule)",
+        "rho_primary": joint["rho_primary"],
+        "rho_info": rho_info,
+        "prior_sd_primary": sd_p,
+        "prior_sd_guard": joint["prior_sd_guard"],
+        "joint": joint,
+        "shrunk": joint["primary_shrunk"],
+        "posterior_sd": joint["primary_posterior_sd"],
+        **prior_meta,
+        **agg,
+    }
+
+
 def process_level_total_effect(
     effects,
     standard_errors,

--- a/experiment_utils/utils.py
+++ b/experiment_utils/utils.py
@@ -1078,8 +1078,11 @@ from .shrinkage import (  # noqa: E402, F401
     fit_t_prior,
     fit_t_prior_with_estimated_mean,
     joint_metric_shrinkage,
+    joint_metric_shrinkage_mvn,
     nss_adjusted_cumulative_impact,
+    nss_adjusted_cumulative_impact_mvn,
     process_level_total_effect,
+    resolve_mvn_prior_sd,
     t_prior_shrinkage,
     winners_curse_estimate,
 )

--- a/tests/test_joint_metric_shrinkage_mvn.py
+++ b/tests/test_joint_metric_shrinkage_mvn.py
@@ -1,0 +1,397 @@
+"""Tests + Monte Carlo recovery for joint_metric_shrinkage_mvn."""
+
+import numpy as np
+import pytest
+from scipy.stats import norm
+
+from experiment_utils.shrinkage import (
+    aggregate_shrunk_cumulative,
+    cumulative_impact,
+    empirical_bayes_shrinkage,
+    joint_metric_shrinkage,
+    joint_metric_shrinkage_mvn,
+    nss_adjusted_cumulative_impact_mvn,
+)
+
+
+def _as_guard_list(g: np.ndarray, sg: np.ndarray):
+    """(n, K) -> list of columns."""
+    return [g[:, k] for k in range(g.shape[1])], [sg[:, k] for k in range(sg.shape[1])]
+
+
+def test_k1_matches_bivariate():
+    rng = np.random.default_rng(0)
+    n = 40
+    x = rng.normal(0.01, 0.03, n)
+    g = rng.normal(0.0, 0.02, n)
+    se_p = np.full(n, 0.02)
+    se_g = np.full(n, 0.012)
+    rho, tau = 0.55, 0.018
+    bi = joint_metric_shrinkage(x, se_p, g, se_g, rho=rho, prior_sd_primary=tau, prior_sd_guard=tau)
+    mvn = joint_metric_shrinkage_mvn(
+        x,
+        se_p,
+        [g],
+        [se_g],
+        rho_primary=rho,
+        prior_sd_primary=tau,
+        prior_sd_guard=tau,
+    )
+    assert np.allclose(mvn["primary_shrunk"], bi["primary_shrunk"], atol=1e-10)
+    assert np.allclose(mvn["primary_posterior_sd"], bi["primary_posterior_sd"], atol=1e-10)
+    assert np.allclose(mvn["guard_shrunk"][:, 0], bi["guard_shrunk"], atol=1e-10)
+
+
+def test_rho0_matches_univariate_eb():
+    rng = np.random.default_rng(1)
+    n = 50
+    tau = 0.02
+    x = rng.normal(0.0, 0.03, n)
+    se_p = np.full(n, 0.025)
+    g = np.column_stack([rng.normal(0, 0.02, n) for _ in range(3)])
+    se_g = np.full_like(g, 0.015)
+    gl, gsl = _as_guard_list(g, se_g)
+    mvn = joint_metric_shrinkage_mvn(
+        x,
+        se_p,
+        gl,
+        gsl,
+        rho_primary=[0.0, 0.0, 0.0],
+        prior_sd_primary=tau,
+        prior_sd_guard=tau,
+    )
+    univ = empirical_bayes_shrinkage(x, se_p, prior_mean=0.0, tau2=tau**2)
+    assert np.allclose(mvn["primary_shrunk"], univ["shrunk"], atol=1e-10)
+    assert np.allclose(mvn["primary_posterior_sd"], univ["posterior_sd"], atol=1e-10)
+
+
+def test_nss_mvn_equals_compose():
+    rng = np.random.default_rng(2)
+    n = 40
+    x = rng.normal(0.01, 0.03, n)
+    se_p = np.full(n, 0.02)
+    g = np.column_stack([rng.normal(0, 0.02, n) for _ in range(2)])
+    se_g = np.full_like(g, 0.012)
+    gl, gsl = _as_guard_list(g, se_g)
+    ship = x > 1.5 * se_p
+    if ship.sum() < 2:
+        ship[:3] = True
+    rho = [0.4, 0.3]
+    tau = 0.015
+    nss = nss_adjusted_cumulative_impact_mvn(
+        x,
+        se_p,
+        gl,
+        gsl,
+        shipped=ship,
+        rho_primary=rho,
+        prior_sd_primary=tau,
+        prior_sd_guard=tau,
+    )
+    joint = joint_metric_shrinkage_mvn(
+        x,
+        se_p,
+        gl,
+        gsl,
+        rho_primary=rho,
+        prior_sd_primary=tau,
+        prior_sd_guard=tau,
+    )
+    agg = aggregate_shrunk_cumulative(
+        joint["primary_shrunk"],
+        joint["primary_posterior_sd"],
+        shipped=ship,
+        observed=x,
+    )
+    assert nss["cumulative"] == pytest.approx(agg["cumulative"])
+    assert nss["ci_lower"] == pytest.approx(agg["ci_lower"])
+    assert np.allclose(nss["shrunk"], joint["primary_shrunk"])
+
+
+def test_accepts_2d_array_and_flexible_k():
+    rng = np.random.default_rng(3)
+    n = 20
+    x = rng.normal(0, 0.02, n)
+    se_p = np.full(n, 0.02)
+    for k in (1, 3, 5, 10):
+        g = rng.normal(0, 0.02, size=(n, k))
+        se_g = np.full((n, k), 0.015)
+        out = joint_metric_shrinkage_mvn(
+            x,
+            se_p,
+            g,
+            se_g,
+            rho_primary=0.2,
+            prior_sd_primary=0.015,
+        )
+        assert out["primary_shrunk"].shape == (n,)
+        assert out["guard_shrunk"].shape == (n, k)
+        assert np.all(np.isfinite(out["primary_shrunk"]))
+
+
+def test_validation():
+    with pytest.raises(ValueError, match="rho"):
+        joint_metric_shrinkage_mvn(
+            [0.1],
+            [0.05],
+            [[0.0]],
+            [[0.05]],
+            rho_primary=1.0,
+            prior_sd_primary=0.02,
+        )
+    with pytest.raises(ValueError, match="positive definite|correlation|PD"):
+        R = np.array([[1.0, 0.99], [0.99, 1.0]])
+        joint_metric_shrinkage_mvn(
+            [0.1, 0.2, 0.0],
+            [0.05, 0.05, 0.05],
+            np.zeros((3, 2)),
+            np.full((3, 2), 0.05),
+            rho_primary=[0.99, -0.99],
+            prior_sd_primary=0.02,
+            prior_sd_guard=0.02,
+            rho_guardrails=R,
+        )
+
+
+def test_prior_map_and_t_scale_plug_in():
+    """prior='map' / t-scale resolve to prior_sd; match explicit SD when plugged."""
+    from experiment_utils.shrinkage import fit_t_prior, resolve_mvn_prior_sd
+
+    rng = np.random.default_rng(9)
+    n = 60
+    x = rng.normal(0.0, 0.03, n)
+    se_p = np.full(n, 0.025)
+    g = np.column_stack([rng.normal(0, 0.02, n) for _ in range(2)])
+    se_g = np.full_like(g, 0.015)
+
+    resolved_map = resolve_mvn_prior_sd(x, se_p, prior="map")
+    mvn_map = joint_metric_shrinkage_mvn(x, se_p, g, se_g, rho_primary=[0.5, 0.4], prior="map")
+    assert mvn_map["prior_source"] == "half_cauchy_map"
+    assert mvn_map["prior_sd_primary"] == pytest.approx(resolved_map["prior_sd"])
+
+    t_fit = fit_t_prior(x, se_p, df=4.0, prior_mean=0.0)
+    mvn_t = joint_metric_shrinkage_mvn(
+        x,
+        se_p,
+        g,
+        se_g,
+        rho_primary=[0.5, 0.4],
+        prior={"scale": t_fit["scale"], "df": 4.0, "prior_mean": 0.0},
+    )
+    assert mvn_t["prior_source"] == "t_scale_plug_in"
+    assert mvn_t["prior_sd_primary"] == pytest.approx(t_fit["scale"])
+
+    # Same τ via prior= vs prior_sd_primary → identical primary
+    tau = 0.02
+    a = joint_metric_shrinkage_mvn(x, se_p, g, se_g, rho_primary=[0.5, 0.4], prior={"tau2": tau**2})
+    b = joint_metric_shrinkage_mvn(x, se_p, g, se_g, rho_primary=[0.5, 0.4], prior_sd_primary=tau)
+    assert np.allclose(a["primary_shrunk"], b["primary_shrunk"], atol=1e-10)
+
+    with pytest.raises(ValueError, match="only one of prior"):
+        joint_metric_shrinkage_mvn(x, se_p, g, se_g, rho_primary=0.3, prior="map", prior_sd_primary=0.02)
+
+
+def _sim_independent_guards(rng, n, tau, rhos, se_p, se_g):
+    k = len(rhos)
+    delta = tau * rng.standard_normal(n)
+    g_true = np.empty((n, k))
+    for j, rho in enumerate(rhos):
+        g_true[:, j] = rho * delta + tau * np.sqrt(1 - rho**2) * rng.standard_normal(n)
+    x = delta + rng.normal(0, se_p, n)
+    g = g_true + rng.normal(0, se_g, size=(n, k))
+    return delta, x, g
+
+
+def test_r1_mvn_mse_beats_primary_only():
+    """R1: K=3 informative independent guards → MVN primary MSE < univariate EB."""
+    rng = np.random.default_rng(42)
+    n_exp, n_sim = 100, 250
+    tau = 0.015
+    rhos = (0.8, 0.7, 0.6)
+    se_p, se_g = 0.03, 0.01
+    mse_univ, mse_mvn = [], []
+    for _ in range(n_sim):
+        delta, x, g = _sim_independent_guards(rng, n_exp, tau, rhos, se_p, se_g)
+        se_p_a = np.full(n_exp, se_p)
+        se_g_a = np.full_like(g, se_g)
+        univ = empirical_bayes_shrinkage(x, se_p_a, prior_mean=0.0, tau2=tau**2)
+        mvn = joint_metric_shrinkage_mvn(
+            x,
+            se_p_a,
+            g,
+            se_g_a,
+            rho_primary=list(rhos),
+            prior_sd_primary=tau,
+            prior_sd_guard=tau,
+        )
+        mse_univ.append(float(np.mean((univ["shrunk"] - delta) ** 2)))
+        mse_mvn.append(float(np.mean((mvn["primary_shrunk"] - delta) ** 2)))
+    assert float(np.mean(mse_mvn)) < float(np.mean(mse_univ))
+
+
+def test_r2_mvn_mse_le_best_bivariate():
+    """R2: MVN MSE ≤ best single-companion bivariate (+ small tol)."""
+    rng = np.random.default_rng(43)
+    n_exp, n_sim = 100, 200
+    tau = 0.015
+    rhos = (0.8, 0.7, 0.6)
+    se_p, se_g = 0.03, 0.01
+    mse_mvn, mse_best_bi = [], []
+    for _ in range(n_sim):
+        delta, x, g = _sim_independent_guards(rng, n_exp, tau, rhos, se_p, se_g)
+        se_p_a = np.full(n_exp, se_p)
+        se_g_a = np.full_like(g, se_g)
+        mvn = joint_metric_shrinkage_mvn(
+            x,
+            se_p_a,
+            g,
+            se_g_a,
+            rho_primary=list(rhos),
+            prior_sd_primary=tau,
+            prior_sd_guard=tau,
+        )
+        bi_mses = []
+        for j, rho in enumerate(rhos):
+            bi = joint_metric_shrinkage(
+                x,
+                se_p_a,
+                g[:, j],
+                se_g_a[:, j],
+                rho=rho,
+                prior_sd_primary=tau,
+                prior_sd_guard=tau,
+            )
+            bi_mses.append(float(np.mean((bi["primary_shrunk"] - delta) ** 2)))
+        mse_mvn.append(float(np.mean((mvn["primary_shrunk"] - delta) ** 2)))
+        mse_best_bi.append(min(bi_mses))
+    assert float(np.mean(mse_mvn)) <= float(np.mean(mse_best_bi)) * 1.02
+
+
+def test_r3_primary_ci_coverage_fixed_sigma():
+    """R3: primary CI coverage ≈ 0.95 under known Sigma."""
+    rng = np.random.default_rng(7)
+    n_exp, n_sim = 80, 350
+    tau = 0.02
+    rhos = (0.6, 0.5, 0.4)
+    se_p, se_g = 0.025, 0.012
+    covered = 0
+    total = 0
+    for _ in range(n_sim):
+        delta, x, g = _sim_independent_guards(rng, n_exp, tau, rhos, se_p, se_g)
+        mvn = joint_metric_shrinkage_mvn(
+            x,
+            np.full(n_exp, se_p),
+            g,
+            np.full_like(g, se_g),
+            rho_primary=list(rhos),
+            prior_sd_primary=tau,
+            prior_sd_guard=tau,
+            ci=0.95,
+        )
+        lo, hi = mvn["primary_ci_lower"], mvn["primary_ci_upper"]
+        covered += int(np.sum((lo <= delta) & (delta <= hi)))
+        total += n_exp
+    rate = covered / total
+    assert 0.88 <= rate <= 0.99
+
+
+def test_r4_redundant_guards_still_beat_primary():
+    """R4: highly correlated guards via R; MVN still beats primary-only MSE."""
+    rng = np.random.default_rng(11)
+    n_exp, n_sim = 100, 200
+    tau, rho = 0.015, 0.75
+    se_p, se_g = 0.03, 0.01
+    R = np.array([[1.0, 0.9], [0.9, 1.0]])
+    mse_univ, mse_mvn = [], []
+    for _ in range(n_sim):
+        sd = np.array([tau, tau, tau])
+        corr = np.array(
+            [
+                [1.0, rho, rho],
+                [rho, 1.0, 0.9],
+                [rho, 0.9, 1.0],
+            ]
+        )
+        sigma = np.outer(sd, sd) * corr
+        m = rng.multivariate_normal(np.zeros(3), sigma, size=n_exp)
+        delta, g1, g2 = m[:, 0], m[:, 1], m[:, 2]
+        x = delta + rng.normal(0, se_p, n_exp)
+        g = np.column_stack([g1 + rng.normal(0, se_g, n_exp), g2 + rng.normal(0, se_g, n_exp)])
+        univ = empirical_bayes_shrinkage(x, np.full(n_exp, se_p), prior_mean=0.0, tau2=tau**2)
+        mvn = joint_metric_shrinkage_mvn(
+            x,
+            np.full(n_exp, se_p),
+            g,
+            np.full_like(g, se_g),
+            rho_primary=[rho, rho],
+            prior_sd_primary=tau,
+            prior_sd_guard=tau,
+            rho_guardrails=R,
+        )
+        mse_univ.append(float(np.mean((univ["shrunk"] - delta) ** 2)))
+        mse_mvn.append(float(np.mean((mvn["primary_shrunk"] - delta) ** 2)))
+        assert np.all(np.isfinite(mvn["primary_shrunk"]))
+    assert float(np.mean(mse_mvn)) < float(np.mean(mse_univ))
+
+
+def test_r5_cumulative_recovers_vs_naive():
+    """R5: MVN cumulative |bias| much smaller than naive shipped sum."""
+    rng = np.random.default_rng(21)
+    n_exp, n_sim = 100, 250
+    tau = 0.015
+    rhos = (0.75, 0.7, 0.65)
+    se_p, se_g = 0.03, 0.01
+    z = norm.ppf(0.975)
+    true_sums, naive_sums, mvn_sums = [], [], []
+    for _ in range(n_sim):
+        delta, x, g = _sim_independent_guards(rng, n_exp, tau, rhos, se_p, se_g)
+        ship = (x > z * se_p) & np.all(g >= 0.0, axis=1)
+        if ship.sum() < 2:
+            continue
+        true_sums.append(float(delta[ship].sum()))
+        naive_sums.append(float(x[ship].sum()))
+        nss = nss_adjusted_cumulative_impact_mvn(
+            x,
+            np.full(n_exp, se_p),
+            g,
+            np.full_like(g, se_g),
+            shipped=ship,
+            rho_primary=list(rhos),
+            prior_sd_primary=tau,
+            prior_sd_guard=tau,
+        )
+        mvn_sums.append(nss["cumulative"])
+    true_sums = np.asarray(true_sums)
+    naive_bias = float(np.mean(np.asarray(naive_sums) - true_sums))
+    mvn_bias = float(np.mean(np.asarray(mvn_sums) - true_sums))
+    assert naive_bias > 0.05
+    assert abs(mvn_bias) < abs(naive_bias)
+    assert abs(mvn_bias) < 0.5 * abs(naive_bias)
+
+
+def test_r6_plugin_rho_beats_primary_only():
+    """R6: MoM rho per pair (known τ) still beats primary-only MSE on average."""
+    rng = np.random.default_rng(33)
+    n_exp, n_sim = 120, 200
+    tau = 0.018
+    rhos = (0.75, 0.7, 0.65)
+    se_p, se_g = 0.028, 0.012
+    mse_univ, mse_mvn = [], []
+    for _ in range(n_sim):
+        delta, x, g = _sim_independent_guards(rng, n_exp, tau, rhos, se_p, se_g)
+        se_p_a = np.full(n_exp, se_p)
+        se_g_a = np.full_like(g, se_g)
+        univ = cumulative_impact(x, se_p_a, tau2=tau**2, prior_mean=0.0)
+        nss = nss_adjusted_cumulative_impact_mvn(
+            x,
+            se_p_a,
+            g,
+            se_g_a,
+            shipped=np.ones(n_exp, dtype=bool),
+            # estimate rho only; fix τ to avoid PM→0 edge cases
+            prior_sd_primary=tau,
+            prior_sd_guard=tau,
+        )
+        mse_univ.append(float(np.mean((univ["shrunk"] - delta) ** 2)))
+        mse_mvn.append(float(np.mean((nss["shrunk"] - delta) ** 2)))
+    assert float(np.mean(mse_mvn)) < float(np.mean(mse_univ))


### PR DESCRIPTION
## Summary
- Add `joint_metric_shrinkage_mvn` / `nss_adjusted_cumulative_impact_mvn`: Bayes normal–normal primary posterior given flexible \(K\) NSS companions (default `rho_guardrails="factor"`).
- Add `resolve_mvn_prior_sd` and `prior=` (`"map"` / `{"tau2"}` / t-scale plug-in) — still normal MVN under the hood, not multivariate-t.
- CI recovery tests (K=1 ≡ bivariate, MSE vs primary-only / best bivariate, CI coverage, redundant guards, cumulative, plug-in ρ) plus example comparing MVN vs one companion under the company NSS scale gate (block if any up-metric is significantly negative at p < 0.1).

**Magnitude only — not the scale rule.** Keep the multi-NSS hard gate in `shipped`.


### Statistical claims validated by simulation
- \(K=1\) matches bivariate `joint_metric_shrinkage`
- Multi-guard MVN primary MSE < primary-only and ≤ best single bivariate (known Σ)
- Primary CI coverage ≈ 0.95 under fixed Σ
- Cumulative |bias| ≪ naive under shipped mask
- Example: MVN beats best one-guardrail under company NSS p<0.1 gate; MAP/t-scale plug-in still beats one-guardrail

## Test plan
- [x] `uv run pytest tests/test_joint_metric_shrinkage_mvn.py`
- [x] `uv run ruff check` / `ruff format --check` on touched files
- [x] `uv run python examples/joint_metric_shrinkage_mvn.py` (sections 1–3 PASS)