### PR TITLE
fix: drop NSS self-slot in MVN when primary is a companion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+* add `primary_metric=` (+ `guardrail_names=`) on `joint_metric_shrinkage_mvn` / `nss_adjusted_cumulative_impact_mvn` — when the primary is one of the companions, drop that self-slot and estimate \(\hat\rho\) on companion-only rows (magnitude only — not the ship rule)
 * add optional `weights=` / `normalize=` on `fit_t_prior` and `fit_t_prior_with_estimated_mean` (weighted Student-t profile likelihood), plus `recency_weights(dates, half_life_days, as_of=...)` — analysis choices only; not part of the ship rule / NSS gate
 * move portfolio shrinkage APIs into `experiment_utils.shrinkage` (winner's curse, EB / t-prior, cumulative impact, joint / NSS, Airbnb \(\hat T_A\), MAP); re-exported from the package top-level and from `experiment_utils.utils` for compatibility — prefer `from experiment_utils.shrinkage import ...`
 * add `aggregate_shrunk_cumulative` and `nss_adjusted_cumulative_impact` (joint primary|guardrail shrink, then Kessler aggregate on primary)
@@ -15,6 +16,7 @@
 * Prior `weights=` reweight archive rows when learning a Student-t prior; half-life / recency policy stays with the caller. Do not confuse with `shipped` or NSS gates.
 * NSS-adjusted cumulative helps on average when |ρ| is high and the guardrail is precise; at moderate ρ a single portfolio can look worse than primary-only EB (sampling noise)
 * Multi-guardrail MVN pools companions under a joint prior (default factor Corr(γⱼ,γₖ)=ρⱼρₖ). Keep the multi-NSS hard gate in `shipped`; do not use MVN as the ship rule. `"independent"` NSS–NSS correlations can yield a non-PD Σ when several |ρ| are large.
+* When the primary *is* an NSS metric, pass `primary_metric=` so MVN does not condition on the self-slot. Filling that metric remains correct for the ship/hard gate checklist only.
 
 ## [1.4.0](https://github.com/sdaza/experiment-utils-pd/compare/v1.3.0...v1.4.0) (2026-07-27)
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Source code: https://github.com/sdaza/experiment-utils-pd
 - **Equivalence Testing (TOST)**: Two One-Sided Tests for equivalence, non-inferiority, non-superiority, and minimum-effect (superiority by margin) following Lakens (2017, 2018), with absolute, relative, and Cohen's d bounds, Lakens' four-cell conclusion matrix, and dedicated visualization
 - **Power Analysis**: Calculate statistical power and find optimal sample sizes, including TOST equivalence power
 - **Retrodesign Analysis**: Assess reliability of study designs (Type S/M errors)
-- **Winner's-Curse Correction**: De-bias effects selected by significance — conditional truncated-normal estimate with selection-adjusted CI (two-sided or one-sided), empirical-Bayes / Student-t / Half-Cauchy-MAP shrinkage, program-level `cumulative_impact` / NSS-adjusted cumulative, Airbnb `process_level_total_effect`, optional `joint_metric_shrinkage` / `joint_metric_shrinkage_mvn` with `estimate_guardrail_rho` (all in `experiment_utils.shrinkage`), plus analyzer wrappers (`winners_curse_summary`, `cumulative_impact_summary`)
+- **Winner's-Curse Correction**: De-bias effects selected by significance — conditional truncated-normal estimate with selection-adjusted CI (two-sided or one-sided), empirical-Bayes / Student-t / Half-Cauchy-MAP shrinkage, program-level `cumulative_impact` / NSS-adjusted cumulative, Airbnb `process_level_total_effect`, optional `joint_metric_shrinkage` / `joint_metric_shrinkage_mvn` (`primary_metric=` drops self-slot companions) with `estimate_guardrail_rho` (all in `experiment_utils.shrinkage`), plus analyzer wrappers (`winners_curse_summary`, `cumulative_impact_summary`)
 - **Random Assignment**: Generate balanced treatment assignments with stratification
 
 ## Table of Contents
@@ -1715,6 +1715,8 @@ nss_mvn = nss_adjusted_cumulative_impact_mvn(
     shipped=shipped_mask,
     rho_primary=[0.7, 0.5, 0.4],
     prior_sd_primary=0.015,
+    guardrail_names=["nss1", "nss2", "nss3"],
+    primary_metric=target_metric_names,  # drops self-slot when primary ∈ NSS
 )
 
 # Via the analyzer
@@ -1749,7 +1751,9 @@ primary-only EB (sampling noise).
 `nss_adjusted_cumulative_impact_mvn` for primary **magnitude** given several
 NSS companions. Keep the all-pass (or product) hard gate in `shipped` — MVN is
 **not** the scale rule. Default `rho_guardrails="factor"`; `"independent"` can
-make Σ non-PD when several |ρ| are large.
+make Σ non-PD when several |ρ| are large. Pass `primary_metric=` +
+`guardrail_names=` whenever the primary may be one of the companions — the
+self-slot is dropped automatically (ship checklist may still fill that metric).
 
 Runnable examples:
 

--- a/examples/joint_metric_shrinkage_mvn.py
+++ b/examples/joint_metric_shrinkage_mvn.py
@@ -19,6 +19,7 @@ from scipy.stats import norm
 from experiment_utils.shrinkage import (
     cumulative_impact,
     empirical_bayes_shrinkage,
+    exclude_index_from_targets,
     fit_t_prior,
     joint_metric_shrinkage,
     joint_metric_shrinkage_mvn,
@@ -314,4 +315,40 @@ print(
 print(
     "\n  Note: joint remains normal–normal; MAP/t only set prior_sd_primary\n"
     "  (and mean for MAP). Not a multivariate-t posterior."
+)
+
+# %% [markdown]
+# ## 4. Exclude self-slot when primary ∈ companions
+#
+# Pass `primary_metric=` + `guardrail_names=`. Rows whose primary is a companion
+# drop that column (K−1); other rows keep all K.
+
+# %%
+section("4) Exclude self-slot (primary ∈ companions)")
+names3 = ["g0", "g1", "g2"]
+delta, x, g = sim_portfolio(80, tau, rhos3, se_p, se_g)
+# Mix: non-NSS primary (all K) + g0 / g1 / g2 as primary (K−1 each)
+primary_metric = ["other"] * 20 + ["g0"] * 20 + ["g1"] * 20 + ["g2"] * 20
+g_panel = g.copy()
+se_g_panel = np.full_like(g_panel, se_g)
+for j, name in enumerate(names3):
+    mask = np.asarray(primary_metric) == name
+    g_panel[mask, j] = np.nan
+    se_g_panel[mask, j] = np.nan
+excl = joint_metric_shrinkage_mvn(
+    x,
+    np.full(80, se_p),
+    g_panel,
+    se_g_panel,
+    rho_primary=list(rhos3),
+    prior_sd_primary=tau,
+    prior_sd_guard=tau,
+    guardrail_names=names3,
+    primary_metric=primary_metric,
+)
+print(f"  strata_n = {excl['strata_n']}")
+print(f"  primary_shrunk finite? {np.isfinite(excl['primary_shrunk']).all()}")
+print(
+    "  Tip: exclude_index_from_targets(target_names, guardrail_names) "
+    f"→ e.g. {exclude_index_from_targets(['g0', 'other'], names3)}"
 )

--- a/experiment_utils/__init__.py
+++ b/experiment_utils/__init__.py
@@ -6,6 +6,7 @@ from .shrinkage import (
     cumulative_impact,
     empirical_bayes_shrinkage,
     estimate_guardrail_rho,
+    exclude_index_from_targets,
     fit_normal_prior_map,
     fit_t_prior,
     fit_t_prior_with_estimated_mean,
@@ -56,5 +57,6 @@ __all__ = [
     "nss_adjusted_cumulative_impact_mvn",
     "process_level_total_effect",
     "estimate_guardrail_rho",
+    "exclude_index_from_targets",
     "resolve_mvn_prior_sd",
 ]

--- a/experiment_utils/shrinkage.py
+++ b/experiment_utils/shrinkage.py
@@ -1257,6 +1257,66 @@ def _build_prior_sigma(
     return sigma, rho_vec
 
 
+def exclude_index_from_targets(target_names, guardrail_names) -> np.ndarray:
+    """Map per-row primary metric names to companion columns to drop (``-1`` = keep all).
+
+    Used internally when ``primary_metric=`` is passed to the MVN APIs.
+    """
+    names = [str(x).lower() for x in guardrail_names]
+    name_to_j = {name: j for j, name in enumerate(names)}
+    targets = np.asarray([str(t).lower() for t in target_names], dtype=object)
+    return np.asarray(
+        [name_to_j[t] if t in name_to_j else -1 for t in targets],
+        dtype=int,
+    )
+
+
+def _coerce_guardrail_matrix_allowing_self_nan(
+    guardrail_effects,
+    guardrail_ses,
+    n: int,
+    exclude_index: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Like :func:`_coerce_guardrail_matrix`, but NaN allowed only in dropped self-slots."""
+    if isinstance(guardrail_effects, list | tuple):
+        cols = [np.asarray(c, dtype=float).reshape(-1) for c in guardrail_effects]
+        if not cols:
+            raise ValueError("guardrail_effects must contain at least one guardrail")
+        g = np.column_stack(cols)
+    else:
+        g = np.asarray(guardrail_effects, dtype=float)
+        if g.ndim == 1:
+            g = g.reshape(-1, 1)
+        if g.ndim != 2:
+            raise ValueError("guardrail_effects must be a list of arrays or a 2-D array")
+    if isinstance(guardrail_ses, list | tuple):
+        cols = [np.asarray(c, dtype=float).reshape(-1) for c in guardrail_ses]
+        if len(cols) != g.shape[1]:
+            raise ValueError("guardrail_ses must have the same number of columns as guardrail_effects")
+        sg = np.column_stack(cols)
+    else:
+        sg = np.asarray(guardrail_ses, dtype=float)
+        if sg.ndim == 1:
+            sg = sg.reshape(-1, 1)
+        if sg.ndim != 2:
+            raise ValueError("guardrail_ses must be a list of arrays or a 2-D array")
+    if g.shape[0] != n or sg.shape != g.shape:
+        raise ValueError("guardrail arrays must be aligned with primary (n experiments × K guardrails)")
+    k = g.shape[1]
+    for i in range(n):
+        ex = int(exclude_index[i])
+        if ex < -1 or ex >= k:
+            raise ValueError(f"exclude_index[{i}]={ex} out of range for K={k}")
+        for j in range(k):
+            if j == ex:
+                continue
+            if not (np.isfinite(g[i, j]) and np.isfinite(sg[i, j]) and sg[i, j] > 0):
+                raise ValueError(
+                    f"non-excluded guardrail effects/SEs must be finite with positive SE (row {i}, column {j})"
+                )
+    return g, sg
+
+
 def joint_metric_shrinkage_mvn(
     primary_effects,
     primary_ses,
@@ -1272,6 +1332,7 @@ def joint_metric_shrinkage_mvn(
     rho_guardrails="factor",
     ci: float = 0.95,
     guardrail_names=None,
+    primary_metric=None,
 ) -> dict:
     """
     Multivariate normal–normal shrinkage: primary + K guardrails.
@@ -1292,6 +1353,11 @@ def joint_metric_shrinkage_mvn(
     Student-t ``scale`` is plugged in as a normal SD — this is **not** a
     multivariate-t joint (see :func:`resolve_mvn_prior_sd`).
 
+    When ``primary_metric`` is set (with ``guardrail_names``), any row whose
+    primary equals companion ``j`` drops that self-slot (conditions on the other
+    ``K-1``). Self-slot cells may be NaN. Do this whenever the primary *is* one
+    of the companions — never treat the outcome as its own guardrail.
+
     **Magnitude only — not the scale/ship rule.** Keep the multi-guardrail hard
     gate in the caller's ``shipped`` mask; use this for primary magnitude given
     companions.
@@ -1311,6 +1377,11 @@ def joint_metric_shrinkage_mvn(
         Archive prior for the primary (resolved via :func:`resolve_mvn_prior_sd`).
     rho_guardrails : ``"factor"``, ``"independent"``, or (K, K) array
         Correlations among true guardrail effects.
+    guardrail_names : sequence of str, optional
+        Companion names (required if ``primary_metric`` is set).
+    primary_metric : length-n names, optional
+        Per-experiment primary metric. When it matches a companion name, that
+        column is excluded for that row.
     """
     x, sx = _validate_effects_ses(primary_effects, primary_ses)
     if x.size < 1:
@@ -1332,6 +1403,90 @@ def joint_metric_shrinkage_mvn(
         }
     if prior_sd_primary is None:
         raise ValueError("pass prior_sd_primary= or prior= ('map' / {'tau2'} / {'scale','df'})")
+
+    exclude = None
+    if primary_metric is not None:
+        if guardrail_names is None:
+            raise ValueError("primary_metric requires guardrail_names")
+        exclude = exclude_index_from_targets(primary_metric, guardrail_names)
+        if exclude.shape != (x.size,):
+            raise ValueError("primary_metric must be length-n aligned to primary")
+
+    if exclude is not None and np.any(exclude >= 0):
+        g, sg = _coerce_guardrail_matrix_allowing_self_nan(guardrail_effects, guardrail_ses, x.size, exclude)
+        k = g.shape[1]
+        if np.isscalar(rho_primary):
+            rho_vec = np.full(k, float(rho_primary))
+        else:
+            rho_vec = np.asarray(rho_primary, dtype=float).reshape(-1)
+            if rho_vec.size != k:
+                raise ValueError(f"rho_primary must be a scalar or length-{k} sequence")
+        if prior_sd_guard is None:
+            sd_g = np.full(k, float(prior_sd_primary))
+        elif np.isscalar(prior_sd_guard):
+            sd_g = np.full(k, float(prior_sd_guard))
+        else:
+            sd_g = np.asarray(prior_sd_guard, dtype=float).reshape(-1)
+            if sd_g.size != k:
+                raise ValueError(f"prior_sd_guard must be a scalar or length-{k} sequence")
+        names = [str(n).lower() for n in guardrail_names]
+        if len(names) != k:
+            raise ValueError(f"guardrail_names must have length {k}")
+
+        primary_shrunk = np.empty(x.size)
+        primary_sd = np.empty(x.size)
+        strata_n: dict[str, int] = {}
+        for ex in sorted(set(exclude.tolist())):
+            idxs = np.flatnonzero(exclude == ex)
+            cols = list(range(k)) if ex < 0 else [j for j in range(k) if j != ex]
+            if not cols:
+                raise ValueError("cannot exclude the only guardrail column")
+            stratum = "all_k" if ex < 0 else f"drop:{names[ex]}"
+            strata_n[stratum] = int(idxs.size)
+            gmean = prior_mean_guard
+            if np.ndim(prior_mean_guard) != 0:
+                gmean = np.asarray(prior_mean_guard, dtype=float)[cols]
+            joint_s = joint_metric_shrinkage_mvn(
+                x[idxs],
+                sx[idxs],
+                g[idxs][:, cols],
+                sg[idxs][:, cols],
+                rho_primary=rho_vec[cols],
+                prior_sd_primary=float(prior_sd_primary),
+                prior_sd_guard=sd_g[cols],
+                prior_mean_primary=prior_mean_primary,
+                prior_mean_guard=gmean,
+                rho_guardrails=rho_guardrails,
+                ci=ci,
+                guardrail_names=[names[j] for j in cols],
+            )
+            primary_shrunk[idxs] = joint_s["primary_shrunk"]
+            primary_sd[idxs] = joint_s["primary_posterior_sd"]
+
+        z = float(norm.ppf(1.0 - (1.0 - ci) / 2.0))
+        return {
+            "method": "joint_metric_shrinkage_mvn",
+            "primary_shrunk": primary_shrunk,
+            "primary_posterior_sd": primary_sd,
+            "primary_ci_lower": primary_shrunk - z * primary_sd,
+            "primary_ci_upper": primary_shrunk + z * primary_sd,
+            "rho_primary": rho_vec,
+            "prior_sd_primary": float(prior_sd_primary),
+            "prior_sd_guard": sd_g.copy(),
+            "prior_mean_primary": float(prior_mean_primary),
+            "prior_mean_guard": (
+                np.full(k, float(prior_mean_guard))
+                if np.isscalar(prior_mean_guard)
+                else np.asarray(prior_mean_guard, dtype=float).reshape(-1).copy()
+            ),
+            "rho_guardrails": (rho_guardrails if isinstance(rho_guardrails, str) else np.asarray(rho_guardrails)),
+            "n_guardrails": int(k),
+            "guardrail_names": names,
+            "primary_metric_excluded": True,
+            "exclude_index": exclude.copy(),
+            "strata_n": strata_n,
+            **prior_meta,
+        }
 
     g, sg = _coerce_guardrail_matrix(guardrail_effects, guardrail_ses, x.size)
     k = g.shape[1]
@@ -1394,6 +1549,7 @@ def joint_metric_shrinkage_mvn(
         "sigma": sigma,
         "n_guardrails": int(k),
         "guardrail_names": names,
+        "primary_metric_excluded": False,
         **prior_meta,
     }
     return out
@@ -1418,6 +1574,7 @@ def nss_adjusted_cumulative_impact_mvn(
     ci: float = 0.95,
     min_shipped: int = 1,
     guardrail_names=None,
+    primary_metric=None,
 ) -> dict:
     """
     Multi-guardrail MVN joint shrink, then Kessler aggregate on primary.
@@ -1427,6 +1584,10 @@ def nss_adjusted_cumulative_impact_mvn(
     omitted they are estimated via :func:`estimate_guardrail_rho` on each
     primary×NSS pair (``rho_guardrails`` still defaults to ``"factor"``).
 
+    Pass ``primary_metric`` + ``guardrail_names`` whenever the primary may be
+    one of the companions: self-slots are dropped and MoM ``ρ`` uses
+    companion-only rows (never self-copies).
+
     Optional ``prior=`` (``"map"``, ``{"tau2"}``, ``{"scale","df"}``) sets the
     primary normal SD via :func:`resolve_mvn_prior_sd` (still a normal MVN).
 
@@ -1434,7 +1595,17 @@ def nss_adjusted_cumulative_impact_mvn(
     hard gate in ``shipped``.
     """
     y, sy = _validate_effects_ses(primary_effects, primary_ses)
-    g, sg = _coerce_guardrail_matrix(guardrail_effects, guardrail_ses, y.size)
+
+    exclude = None
+    if primary_metric is not None:
+        if guardrail_names is None:
+            raise ValueError("primary_metric requires guardrail_names")
+        exclude = exclude_index_from_targets(primary_metric, guardrail_names)
+        if exclude.shape != (y.size,):
+            raise ValueError("primary_metric must be length-n aligned to primary")
+        g, sg = _coerce_guardrail_matrix_allowing_self_nan(guardrail_effects, guardrail_ses, y.size, exclude)
+    else:
+        g, sg = _coerce_guardrail_matrix(guardrail_effects, guardrail_ses, y.size)
     k = g.shape[1]
 
     prior_meta: dict = {}
@@ -1451,27 +1622,38 @@ def nss_adjusted_cumulative_impact_mvn(
         }
 
     need_mom = rho_primary is None or prior_sd_primary is None or prior_sd_guard is None
+    n_pair: list[int] = []
     if need_mom:
         if y.size < 5:
             raise ValueError(
                 "estimating rho / prior SDs requires at least 5 paired experiments; "
                 "pass rho_primary, prior_sd_primary (or prior=), and prior_sd_guard explicitly"
             )
-        rhos = []
-        tau_gs = []
-        tau_ps = []
+        rhos, tau_gs, tau_ps = [], [], []
         for j in range(k):
+            gmean = (
+                float(prior_mean_guard)
+                if np.isscalar(prior_mean_guard) or np.ndim(prior_mean_guard) == 0
+                else float(np.asarray(prior_mean_guard).reshape(-1)[j])
+            )
+            if exclude is None:
+                mask = np.ones(y.size, dtype=bool)
+            else:
+                mask = (exclude != j) & np.isfinite(g[:, j]) & np.isfinite(sg[:, j]) & (sg[:, j] > 0)
+            n_j = int(mask.sum())
+            n_pair.append(n_j)
+            if n_j < 5:
+                raise ValueError(
+                    f"MoM for guardrail column {j} needs ≥5 usable rows (got {n_j}); "
+                    "pass rho_primary / prior SDs or widen the panel"
+                )
             mom = estimate_guardrail_rho(
-                y,
-                sy,
-                g[:, j],
-                sg[:, j],
+                y[mask],
+                sy[mask],
+                g[mask, j],
+                sg[mask, j],
                 prior_mean_primary=prior_mean_primary,
-                prior_mean_guard=(
-                    float(prior_mean_guard)
-                    if np.isscalar(prior_mean_guard)
-                    else float(np.asarray(prior_mean_guard).reshape(-1)[j])
-                ),
+                prior_mean_guard=gmean,
             )
             rhos.append(mom["rho"])
             tau_gs.append(mom["tau_guard"])
@@ -1495,7 +1677,12 @@ def nss_adjusted_cumulative_impact_mvn(
             sd_g = float(prior_sd_guard)
         else:
             sd_g = prior_sd_guard
-        rho_info = {"rho_primary": rho_hat, "tau_guards": tau_gs, "source": "mom"}
+        rho_info = {
+            "rho_primary": rho_hat,
+            "tau_guards": tau_gs,
+            "n_pair": n_pair,
+            "source": "mom_companion_only" if exclude is not None else "mom",
+        }
     else:
         rho_hat = rho_primary
         sd_p = float(prior_sd_primary)
@@ -1515,6 +1702,7 @@ def nss_adjusted_cumulative_impact_mvn(
         rho_guardrails=rho_guardrails,
         ci=ci,
         guardrail_names=guardrail_names,
+        primary_metric=primary_metric,
     )
     agg = aggregate_shrunk_cumulative(
         joint["primary_shrunk"],
@@ -1526,7 +1714,7 @@ def nss_adjusted_cumulative_impact_mvn(
         ci=ci,
         min_shipped=min_shipped,
     )
-    return {
+    out = {
         "method": "joint_metric_shrinkage_mvn → Kessler aggregate (magnitude; not scale rule)",
         "rho_primary": joint["rho_primary"],
         "rho_info": rho_info,
@@ -1538,6 +1726,10 @@ def nss_adjusted_cumulative_impact_mvn(
         **prior_meta,
         **agg,
     }
+    if joint.get("strata_n") is not None:
+        out["strata_n"] = joint["strata_n"]
+        out["primary_metric_excluded"] = True
+    return out
 
 
 def process_level_total_effect(

--- a/experiment_utils/utils.py
+++ b/experiment_utils/utils.py
@@ -1074,6 +1074,7 @@ from .shrinkage import (  # noqa: E402, F401
     cumulative_impact,
     empirical_bayes_shrinkage,
     estimate_guardrail_rho,
+    exclude_index_from_targets,
     fit_normal_prior_map,
     fit_t_prior,
     fit_t_prior_with_estimated_mean,

--- a/tests/test_mvn_exclude_target.py
+++ b/tests/test_mvn_exclude_target.py
@@ -1,0 +1,355 @@
+"""Tests for MVN self-slot exclusion via primary_metric=."""
+
+import numpy as np
+import pytest
+
+from experiment_utils.shrinkage import (
+    aggregate_shrunk_cumulative,
+    empirical_bayes_shrinkage,
+    estimate_guardrail_rho,
+    exclude_index_from_targets,
+    joint_metric_shrinkage_mvn,
+    nss_adjusted_cumulative_impact_mvn,
+)
+
+
+def test_exclude_index_from_targets():
+    names = ["a", "b", "c"]
+    idx = exclude_index_from_targets(["b", "other", "a"], names)
+    assert list(idx) == [1, -1, 0]
+
+
+def test_primary_metric_none_matches_legacy():
+    rng = np.random.default_rng(0)
+    n, k = 40, 3
+    x = rng.normal(0.01, 0.03, n)
+    se_p = np.full(n, 0.02)
+    g = rng.normal(0.0, 0.02, size=(n, k))
+    se_g = np.full_like(g, 0.012)
+    rho = [0.5, 0.4, 0.3]
+    tau = 0.018
+    a = joint_metric_shrinkage_mvn(x, se_p, g, se_g, rho_primary=rho, prior_sd_primary=tau, prior_sd_guard=tau)
+    b = joint_metric_shrinkage_mvn(
+        x,
+        se_p,
+        g,
+        se_g,
+        rho_primary=rho,
+        prior_sd_primary=tau,
+        prior_sd_guard=tau,
+        guardrail_names=["a", "b", "c"],
+        primary_metric=["other"] * n,
+    )
+    assert np.allclose(a["primary_shrunk"], b["primary_shrunk"], atol=1e-10)
+    assert b["primary_metric_excluded"] is False
+
+
+def test_primary_metric_drops_self_slot():
+    rng = np.random.default_rng(7)
+    n_non, n_a = 20, 25
+    n = n_non + n_a
+    k = 3
+    names = ["a", "b", "c"]
+    x = rng.normal(0.01, 0.02, n)
+    se_p = np.full(n, 0.01)
+    g = rng.normal(0.005, 0.02, (n, k))
+    se_g = np.full((n, k), 0.01)
+    primary_metric = ["other"] * n_non + ["a"] * n_a
+    g[n_non:, 0] = np.nan
+    se_g[n_non:, 0] = np.nan
+    out = joint_metric_shrinkage_mvn(
+        x,
+        se_p,
+        g,
+        se_g,
+        rho_primary=0.4,
+        prior_sd_primary=0.02,
+        prior_sd_guard=0.02,
+        guardrail_names=names,
+        primary_metric=primary_metric,
+    )
+    assert out["primary_metric_excluded"] is True
+    assert out["strata_n"]["all_k"] == n_non
+    assert out["strata_n"]["drop:a"] == n_a
+    assert np.isfinite(out["primary_shrunk"]).all()
+
+
+def test_companion_only_rho_not_pulled_by_self_copies():
+    rng = np.random.default_rng(11)
+    n, n_self = 100, 70
+    true_rho = 0.45
+    tau, se = 0.02, 0.008
+    z = rng.standard_normal(n)
+    delta = tau * z
+    gamma0 = tau * (true_rho * z + np.sqrt(1.0 - true_rho**2) * rng.standard_normal(n))
+    y = delta + se * rng.standard_normal(n)
+    g = np.column_stack(
+        [
+            gamma0 + se * rng.standard_normal(n),
+            tau * rng.standard_normal(n) + se * rng.standard_normal(n),
+            tau * rng.standard_normal(n) + se * rng.standard_normal(n),
+        ]
+    )
+    se_y = np.full(n, se)
+    se_g = np.full((n, 3), se)
+    primary_metric = ["a"] * n_self + ["other"] * (n - n_self)
+    g_filled = g.copy()
+    g_filled[:n_self, 0] = y[:n_self]
+
+    rho_naive = float(estimate_guardrail_rho(y, se_y, g_filled[:, 0], se_g[:, 0])["rho"])
+    excl = nss_adjusted_cumulative_impact_mvn(
+        y,
+        se_y,
+        g_filled,
+        se_g,
+        shipped=np.ones(n, dtype=bool),
+        guardrail_names=["a", "b", "c"],
+        primary_metric=primary_metric,
+    )
+    rho_excl = float(np.asarray(excl["rho_primary"])[0])
+    assert rho_naive > 0.8
+    assert rho_naive > rho_excl + 0.2
+    assert abs(rho_excl - true_rho) < abs(rho_naive - true_rho)
+    assert abs(rho_excl - true_rho) < 0.25
+    assert excl["rho_info"]["source"] == "mom_companion_only"
+
+
+def test_nss_primary_metric_compose():
+    rng = np.random.default_rng(2)
+    n, k = 40, 3
+    names = ["a", "b", "c"]
+    x = rng.normal(0.01, 0.03, n)
+    se_p = np.full(n, 0.02)
+    g = rng.normal(0, 0.02, size=(n, k))
+    se_g = np.full_like(g, 0.012)
+    primary_metric = ["other"] * 20 + ["b"] * 20
+    g[20:, 1] = np.nan
+    se_g[20:, 1] = np.nan
+    ship = np.ones(n, dtype=bool)
+    rho = [0.4, 0.3, 0.35]
+    tau = 0.015
+    nss = nss_adjusted_cumulative_impact_mvn(
+        x,
+        se_p,
+        g,
+        se_g,
+        shipped=ship,
+        rho_primary=rho,
+        prior_sd_primary=tau,
+        prior_sd_guard=tau,
+        guardrail_names=names,
+        primary_metric=primary_metric,
+    )
+    joint = joint_metric_shrinkage_mvn(
+        x,
+        se_p,
+        g,
+        se_g,
+        rho_primary=rho,
+        prior_sd_primary=tau,
+        prior_sd_guard=tau,
+        guardrail_names=names,
+        primary_metric=primary_metric,
+    )
+    agg = aggregate_shrunk_cumulative(
+        joint["primary_shrunk"],
+        joint["primary_posterior_sd"],
+        shipped=ship,
+        observed=x,
+    )
+    assert nss["cumulative"] == pytest.approx(agg["cumulative"])
+    assert np.allclose(nss["shrunk"], joint["primary_shrunk"])
+
+
+def test_r_primary_metric_mse_beats_primary_only():
+    rng = np.random.default_rng(42)
+    n_exp, n_sim = 100, 200
+    tau = 0.015
+    rhos = (0.8, 0.7, 0.6)
+    se_p, se_g = 0.03, 0.01
+    names = ["a", "b", "c"]
+    mse_univ, mse_excl = [], []
+    for _ in range(n_sim):
+        k = len(rhos)
+        delta = tau * rng.standard_normal(n_exp)
+        g_true = np.empty((n_exp, k))
+        for j, rho in enumerate(rhos):
+            g_true[:, j] = rho * delta + tau * np.sqrt(1 - rho**2) * rng.standard_normal(n_exp)
+        x = delta + rng.normal(0, se_p, n_exp)
+        g = g_true + rng.normal(0, se_g, size=(n_exp, k))
+        half = n_exp // 2
+        primary_metric = ["other"] * half + ["a"] * (n_exp - half)
+        g[half:, 0] = np.nan
+        se_g_a = np.full_like(g, se_g)
+        se_g_a[half:, 0] = np.nan
+        se_p_a = np.full(n_exp, se_p)
+        univ = empirical_bayes_shrinkage(x, se_p_a, prior_mean=0.0, tau2=tau**2)
+        excl = joint_metric_shrinkage_mvn(
+            x,
+            se_p_a,
+            g,
+            se_g_a,
+            rho_primary=list(rhos),
+            prior_sd_primary=tau,
+            prior_sd_guard=tau,
+            guardrail_names=names,
+            primary_metric=primary_metric,
+        )
+        mse_univ.append(float(np.mean((univ["shrunk"] - delta) ** 2)))
+        mse_excl.append(float(np.mean((excl["primary_shrunk"] - delta) ** 2)))
+    assert float(np.mean(mse_excl)) < float(np.mean(mse_univ))
+
+
+def test_mixed_primary_metrics_variable_companion_count():
+    """Different primaries → different K used (full K vs K−1 per dropped NSS).
+
+    Panel mixes non-NSS primary (all 5 companions) with each NSS-as-primary
+    (other 4). Joint output must match per-stratum fixed-K MVN oracles and
+    remain finite; strata sizes reflect the mix.
+    """
+    rng = np.random.default_rng(99)
+    names = [
+        "cashflow_gm_cuped",
+        "payment_amount_cuped",
+        "payment_amount_new_tutorings",
+        "hours_confirmed_cuped",
+        "new_tutoring_subscribers",
+    ]
+    k = len(names)
+    # 12 non-NSS + 8 per each of 5 NSS primaries = 52 rows
+    n_non = 12
+    n_per_nss = 8
+    blocks = [("non_nss", n_non)] + [(m, n_per_nss) for m in names]
+    primary_metric = []
+    for label, n_b in blocks:
+        primary_metric.extend([label] * n_b)
+    primary_metric = np.asarray(primary_metric, dtype=object)
+    n = len(primary_metric)
+
+    tau = 0.02
+    rhos = np.array([0.55, 0.50, 0.45, 0.40, 0.35])
+    se_p, se_g = 0.025, 0.012
+    delta = tau * rng.standard_normal(n)
+    g_true = np.empty((n, k))
+    for j, rho in enumerate(rhos):
+        g_true[:, j] = rho * delta + tau * np.sqrt(1 - rho**2) * rng.standard_normal(n)
+    x = delta + rng.normal(0, se_p, n)
+    g = g_true + rng.normal(0, se_g, size=(n, k))
+    se_p_a = np.full(n, se_p)
+    se_g_a = np.full((n, k), se_g)
+
+    # Self-slots NaN when primary is that NSS metric
+    for j, m in enumerate(names):
+        mask = primary_metric == m
+        g[mask, j] = np.nan
+        se_g_a[mask, j] = np.nan
+
+    out = joint_metric_shrinkage_mvn(
+        x,
+        se_p_a,
+        g,
+        se_g_a,
+        rho_primary=rhos,
+        prior_sd_primary=tau,
+        prior_sd_guard=tau,
+        guardrail_names=names,
+        primary_metric=primary_metric,
+    )
+
+    assert out["primary_metric_excluded"] is True
+    assert out["strata_n"]["all_k"] == n_non
+    for m in names:
+        assert out["strata_n"][f"drop:{m}"] == n_per_nss
+    assert np.isfinite(out["primary_shrunk"]).all()
+    assert np.isfinite(out["primary_posterior_sd"]).all()
+
+    # Oracle: each stratum matches a fixed-K call on that companion subset
+    for label, _n_b in blocks:
+        idxs = np.flatnonzero(primary_metric == label)
+        if label == "non_nss":
+            cols = list(range(k))
+        else:
+            j = names.index(label)
+            cols = [c for c in range(k) if c != j]
+        oracle = joint_metric_shrinkage_mvn(
+            x[idxs],
+            se_p_a[idxs],
+            g[idxs][:, cols],
+            se_g_a[idxs][:, cols],
+            rho_primary=rhos[cols],
+            prior_sd_primary=tau,
+            prior_sd_guard=tau,
+            guardrail_names=[names[c] for c in cols],
+        )
+        assert np.allclose(out["primary_shrunk"][idxs], oracle["primary_shrunk"], atol=1e-10)
+        assert np.allclose(
+            out["primary_posterior_sd"][idxs],
+            oracle["primary_posterior_sd"],
+            atol=1e-10,
+        )
+        # Companion count in the oracle path
+        assert oracle["n_guardrails"] == (k if label == "non_nss" else k - 1)
+
+    # K−1 rows should have weakly larger posterior SD than the same row
+    # shrunk with all K (fill self with a distinct noisy companion) — drop
+    # information ⇒ less precise primary. Use a non-self fill for the counterfactual.
+    g_full = g.copy()
+    se_full = se_g_a.copy()
+    for j, m in enumerate(names):
+        mask = primary_metric == m
+        # fill with independent noise (not the primary) so K companions are usable
+        g_full[mask, j] = rng.normal(0.0, 0.02, int(mask.sum()))
+        se_full[mask, j] = se_g
+    full_k = joint_metric_shrinkage_mvn(
+        x,
+        se_p_a,
+        g_full,
+        se_full,
+        rho_primary=rhos,
+        prior_sd_primary=tau,
+        prior_sd_guard=tau,
+    )
+    nss_rows = primary_metric != "non_nss"
+    # Mean posterior SD among NSS-primary rows: excluding self ≥ using a fake extra companion
+    assert (
+        float(np.mean(out["primary_posterior_sd"][nss_rows]))
+        >= float(np.mean(full_k["primary_posterior_sd"][nss_rows])) - 1e-12
+    )
+
+
+def test_mixed_primary_metrics_cumulative_and_mom_pair_counts():
+    """MoM companion-only pair counts reflect which primaries were excluded."""
+    rng = np.random.default_rng(5)
+    names = ["a", "b", "c"]
+    n = 60
+    # 20 each: primary=a, primary=b, primary=other
+    primary_metric = np.array(["a"] * 20 + ["b"] * 20 + ["other"] * 20, dtype=object)
+    y = rng.normal(0.01, 0.02, n)
+    se_y = np.full(n, 0.01)
+    g = rng.normal(0.0, 0.02, (n, 3))
+    se_g = np.full((n, 3), 0.01)
+    g[:20, 0] = np.nan
+    se_g[:20, 0] = np.nan
+    g[20:40, 1] = np.nan
+    se_g[20:40, 1] = np.nan
+
+    out = nss_adjusted_cumulative_impact_mvn(
+        y,
+        se_y,
+        g,
+        se_g,
+        shipped=np.ones(n, dtype=bool),
+        guardrail_names=names,
+        primary_metric=primary_metric,
+        prior_sd_primary=0.02,
+        prior_sd_guard=0.02,
+        # force MoM for rho only
+        rho_primary=None,
+    )
+    # Column a: excluded on 20 rows → MoM uses 40; same for b; c uses all 60
+    assert out["rho_info"]["n_pair"] == [40, 40, 60]
+    assert out["rho_info"]["source"] == "mom_companion_only"
+    assert out["strata_n"]["drop:a"] == 20
+    assert out["strata_n"]["drop:b"] == 20
+    assert out["strata_n"]["all_k"] == 20
+    assert np.isfinite(out["cumulative"])

--- a/uv.lock
+++ b/uv.lock
@@ -402,7 +402,7 @@ wheels = [
 
 [[package]]
 name = "experiment-utils-pd"
-version = "1.3.0"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "lifelines" },


### PR DESCRIPTION
## Summary
- Add `primary_metric=` (+ `guardrail_names=`) to `joint_metric_shrinkage_mvn` / `nss_adjusted_cumulative_impact_mvn` so rows whose primary is itself a companion drop that self-slot (K−1) while non-NSS primaries keep full K
- Estimate \(\hat\rho\) on companion-only pairs when `primary_metric` is set (avoids ρ→1 from filled self-copies)
- Tests cover identity, ρ bias, mixed NSS primaries / variable companion count, and MSE recovery; README / CHANGELOG / example updated

## Statistical claims validated
- Identity: no exclusions → same primary as legacy MVN
- Mixed strata: each primary’s shrunk values match fixed-K oracles on the correct companion subset
- Companion-only MoM recovers moderate ρ when naive MoM on self-copies → ~1
- Exclude-self MVN still beats primary-only EB on MSE under informative companions

## Not the ship rule
Hard NSS gate / checklist fill stays with the caller `shipped` mask. This change is magnitude-only.

## Test plan
- [x] `uv run ruff check` + `ruff format --check` on touched files
- [x] `uv run pytest tests/test_mvn_exclude_target.py tests/test_joint_metric_shrinkage_mvn.py`
- [ ] CI green on PR